### PR TITLE
chore: add SDK ssh key to ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,9 @@ jobs:
     - name: Install Hatch 
       run: |
         python -m pip install --upgrade hatch
+    - uses: webfactory/ssh-agent@v0.9.1
+      with:
+        ssh-private-key: ${{ secrets.SDK_KEY }}
     - name: static analysis
       run: hatch fmt --check
     - name: type checking


### PR DESCRIPTION
Add the SDK repo SSH Key to the CI GitHub Action, so hatch can pull the dependency during build and test in ci.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
