### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 
 name: Python package
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/aws/aws-durable-execution-sdk-python-testing/security/code-scanning/1](https://github.com/aws/aws-durable-execution-sdk-python-testing/security/code-scanning/1)

To resolve the problem, add a `permissions` block to the workflow to explicitly set the minimal required GitHub token permissions. Because the workflow does not perform any write operations (to contents, issues, pull-requests, etc.), it is sufficient to give read-only access to repository contents. Place the `permissions` block at the top level of the workflow, directly below the `name` field (affecting all jobs in the workflow), as recommended by GitHub best practices.

**What to do:**
- Edit `.github/workflows/ci.yml`.
- Add:
  ```yaml
  permissions:
    contents: read
  ```
  after the `name` property and before the `on` property.  
- No additional imports or variable definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
