### PR TITLE
fix: preserve step retry attempt & InvokeOptions update

### DIFF
--- a/src/aws_durable_execution_sdk_python_testing/observer.py
+++ b/src/aws_durable_execution_sdk_python_testing/observer.py
@@ -1,10 +1,15 @@
 """Checkpoint processors can notify the Execution of notable event state changes. Observer pattern."""
 
+from __future__ import annotations
+
 import threading
 from abc import ABC, abstractmethod
-from collections.abc import Callable
+from typing import TYPE_CHECKING
 
-from aws_durable_execution_sdk_python.lambda_service import ErrorObject
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from aws_durable_execution_sdk_python.lambda_service import ErrorObject
 
 
 class ExecutionObserver(ABC):
@@ -34,7 +39,7 @@ class ExecutionObserver(ABC):
 class ExecutionNotifier:
     """Notifies observers about execution events. Thread-safe."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._observers: list[ExecutionObserver] = []
         self._lock = threading.RLock()
 

--- a/tests/e2e/basic_success_path_test.py
+++ b/tests/e2e/basic_success_path_test.py
@@ -68,16 +68,16 @@ def test_basic_durable_function() -> None:
         result: DurableFunctionTestResult = runner.run(input="input str", timeout=10)
 
     assert result.status is InvocationStatus.SUCCEEDED
-    assert result.result == '["1 2", "3 4 4 3", "5 6"]'
+    assert result.result == ["1 2", "3 4 4 3", "5 6"]
 
     one_result: StepOperation = result.get_step("one")
-    assert one_result.result == '"1 2"'
+    assert one_result.result == "1 2"
 
     two_result: ContextOperation = result.get_context("two")
-    assert two_result.result == '"3 4 4 3"'
+    assert two_result.result == "3 4 4 3"
 
     three_result: StepOperation = result.get_step("three")
-    assert three_result.result == '"5 6"'
+    assert three_result.result == "5 6"
 
     # currently has the optimization where it's not saving child checkpoints after parent done
     # prob should unpick that for test


### PR DESCRIPTION
-  Fix checkpoint processor to preserve attempt count and timestamp
- Deserialize types on output
- Add DurableChildContextTestRunner



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
