### PR TITLE
fix: next_attempt_timestamp from str to datetime

### DIFF
--- a/src/aws_durable_execution_sdk_python_testing/checkpoint/processors/base.py
+++ b/src/aws_durable_execution_sdk_python_testing/checkpoint/processors/base.py
@@ -75,7 +75,7 @@ class OperationProcessor:
     ) -> StepDetails | None:
         """Create StepDetails from OperationUpdate."""
         attempt: int = 0
-        next_attempt_timestamp: str | None = None
+        next_attempt_timestamp: datetime.datetime | None = None
 
         if update.operation_type is OperationType.STEP:
             if current_operation and current_operation.step_details:

--- a/src/aws_durable_execution_sdk_python_testing/checkpoint/processors/step.py
+++ b/src/aws_durable_execution_sdk_python_testing/checkpoint/processors/step.py
@@ -57,7 +57,7 @@ class StepProcessor(OperationProcessor):
                 )
                 new_step_details = StepDetails(
                     attempt=current_attempt + 1,
-                    next_attempt_timestamp=str(next_attempt_time),
+                    next_attempt_timestamp=next_attempt_time,
                     result=(
                         current_op.step_details.result
                         if current_op and current_op.step_details

--- a/src/aws_durable_execution_sdk_python_testing/runner.py
+++ b/src/aws_durable_execution_sdk_python_testing/runner.py
@@ -165,7 +165,7 @@ class ContextOperation(Operation):
 @dataclass(frozen=True)
 class StepOperation(ContextOperation):
     attempt: int = 0
-    next_attempt_timestamp: str | None = None
+    next_attempt_timestamp: datetime.datetime | None = None
     result: Any = None
     error: ErrorObject | None = None
 


### PR DESCRIPTION
next_attempt_timestamp is a datetime now, not a str.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
