### PR TITLE
fix: dont parse request bodies on GET requests

### DIFF
--- a/src/aws_durable_execution_sdk_python_testing/web/models.py
+++ b/src/aws_durable_execution_sdk_python_testing/web/models.py
@@ -64,8 +64,12 @@ class HTTPRequest:
         if query_params is None:
             query_params = {}
 
+        # Skip body parsing for GET requests
+        if method == "GET":
+            body_dict = {}
+            logger.debug("GET request, skipping body parsing")
         # Try AWS deserialization first if operation_name provided
-        if operation_name:
+        elif operation_name:
             try:
                 deserializer = AwsRestJsonDeserializer.create(operation_name)
                 body_dict = deserializer.from_bytes(body_bytes)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
GET requests don't have JSON bodies -- right now calling `GetDurableExecution` API is failing on a JSON decode error since no request body is provided. This PR fixes it so that we don't try parsing request bodies for GET requests.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
