### PR TITLE
feat: add PUT /lambda-endpoint route to update lambda client endpoint

### DIFF
--- a/src/aws_durable_execution_sdk_python_testing/invoker.py
+++ b/src/aws_durable_execution_sdk_python_testing/invoker.py
@@ -68,6 +68,10 @@ class Invoker(Protocol):
         input: DurableExecutionInvocationInput,
     ) -> DurableExecutionInvocationOutput: ...  # pragma: no cover
 
+    def update_endpoint(
+        self, endpoint_url: str, region_name: str
+    ) -> None: ...  # pragma: no cover
+
 
 class InProcessInvoker(Invoker):
     def __init__(self, handler: Callable, service_client: InMemoryServiceClient):
@@ -102,6 +106,9 @@ class InProcessInvoker(Invoker):
         response_dict = self.handler(input_with_client, context)
         return DurableExecutionInvocationOutput.from_dict(response_dict)
 
+    def update_endpoint(self, endpoint_url: str, region_name: str) -> None:
+        """No-op for in-process invoker."""
+
 
 class LambdaInvoker(Invoker):
     def __init__(self, lambda_client: Any) -> None:
@@ -114,6 +121,12 @@ class LambdaInvoker(Invoker):
             boto3.client(
                 "lambdainternal", endpoint_url=endpoint_url, region_name=region_name
             )
+        )
+
+    def update_endpoint(self, endpoint_url: str, region_name: str) -> None:
+        """Update the Lambda client endpoint."""
+        self.lambda_client = boto3.client(
+            "lambdainternal", endpoint_url=endpoint_url, region_name=region_name
         )
 
     def create_invocation_input(

--- a/src/aws_durable_execution_sdk_python_testing/web/routes.py
+++ b/src/aws_durable_execution_sdk_python_testing/web/routes.py
@@ -562,6 +562,36 @@ class HealthRoute(Route):
 
 
 @dataclass(frozen=True)
+class UpdateLambdaEndpointRoute(Route):
+    """Route: PUT /lambda-endpoint"""
+
+    @classmethod
+    def is_match(cls, route: Route, method: str) -> bool:
+        """Check if the route and HTTP method match this route type.
+
+        Args:
+            route: Route to check
+            method: HTTP method to check
+
+        Returns:
+            True if the route and method match
+        """
+        return route.raw_path == "/lambda-endpoint" and method == "PUT"
+
+    @classmethod
+    def from_route(cls, route: Route) -> UpdateLambdaEndpointRoute:
+        """Create UpdateLambdaEndpointRoute from base route.
+
+        Args:
+            route: Base route to convert
+
+        Returns:
+            UpdateLambdaEndpointRoute instance
+        """
+        return cls(raw_path=route.raw_path, segments=route.segments)
+
+
+@dataclass(frozen=True)
 class MetricsRoute(Route):
     """Route: GET /metrics"""
 
@@ -607,6 +637,7 @@ DEFAULT_ROUTE_TYPES: list[type[Route]] = [
     CallbackFailureRoute,
     CallbackHeartbeatRoute,
     HealthRoute,
+    UpdateLambdaEndpointRoute,
     MetricsRoute,
 ]
 

--- a/src/aws_durable_execution_sdk_python_testing/web/server.py
+++ b/src/aws_durable_execution_sdk_python_testing/web/server.py
@@ -35,6 +35,7 @@ from aws_durable_execution_sdk_python_testing.web.handlers import (
     SendDurableExecutionCallbackSuccessHandler,
     StartExecutionHandler,
     StopDurableExecutionHandler,
+    UpdateLambdaEndpointHandler,
 )
 from aws_durable_execution_sdk_python_testing.web.models import (
     HTTPRequest,
@@ -56,6 +57,7 @@ from aws_durable_execution_sdk_python_testing.web.routes import (
     Router,
     StartExecutionRoute,
     StopDurableExecutionRoute,
+    UpdateLambdaEndpointRoute,
 )
 
 
@@ -90,6 +92,10 @@ class RequestHandler(BaseHTTPRequestHandler):
     def do_POST(self) -> None:  # noqa: N802
         """Handle POST requests."""
         self._handle_request("POST")
+
+    def do_PUT(self) -> None:  # noqa: N802
+        """Handle PUT requests."""
+        self._handle_request("PUT")
 
     def _handle_request(self, method: str) -> None:
         """Handle HTTP request with strongly-typed routing."""
@@ -212,6 +218,7 @@ class WebServer(ThreadingHTTPServer):
                 self.executor
             ),
             HealthRoute: HealthHandler(self.executor),
+            UpdateLambdaEndpointRoute: UpdateLambdaEndpointHandler(self.executor),
             MetricsRoute: MetricsHandler(self.executor),
         }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adding a new route to the web layer that allows us to dynamically update the lambda invoke endpoint of the server. This is needed for SAM CLI because ports are assigned dynamically, and we need to update the emulator lambda endpoint to the port that gets exposed for the lambda RIE.

Tested it by running the server locally and validating the API calls work:
```
➜  aws-durable-execution-sdk-python-testing git:(feat/add-put-lambda-endpoint) curl -X PUT http://localhost:5002/lambda-endpoint \
  -H "Content-Type: application/json" \
  -d '{
    "EndpointUrl": "http://localhost:9000"
  }'
➜  aws-durable-execution-sdk-python-testing git:(feat/add-put-lambda-endpoint) curl -X PUT http://localhost:5002/lambda-endpoint \     
  -H "Content-Type: application/json" \
  -d '{
    "EndpointUrl": "http://localhost:9000",
    "RegionName": "us-west-2"  
  }'                               
{"message":"Lambda endpoint updated successfully"
```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
