### PR TITLE
fix: rename wait options model from seconds to wait_seconds

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,10 @@
+*Issue #, if available:*
+
+*Description of changes:*
+
+## Dependencies
+If this PR requires testing against a specific branch of the Python Language SDK (e.g., for unreleased changes), uncomment and specify the branch below. Otherwise, leave commented to use the main branch.
+
+<!-- PYTHON_LANGUAGE_SDK_BRANCH: branch-name -->
+
+By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ permissions:
 
 on:
   push:
-
+    branches: [ main ]
   pull_request:
     branches: [ main ]
 
@@ -32,6 +32,16 @@ jobs:
     - uses: webfactory/ssh-agent@v0.9.1
       with:
         ssh-private-key: ${{ secrets.SDK_KEY }}
+    - name: Check for Python Language SDK branch override in PR
+      if: github.event_name == 'pull_request'
+      run: |
+        OVERRIDE=$(echo "${{ github.event.pull_request.body }}" | grep -o 'PYTHON_LANGUAGE_SDK_BRANCH: [^[:space:]]*' | cut -d' ' -f2 || true)
+        if [ ! -z "$OVERRIDE" ]; then
+          echo "AWS_DURABLE_SDK_URL=git+ssh://git@github.com/aws/aws-durable-execution-sdk-python.git@$OVERRIDE" >> $GITHUB_ENV
+          echo "Using Python Language SDK branch override: $OVERRIDE"
+        else
+          echo "Using default Python Language SDK (main branch)"
+        fi
     - name: static analysis
       run: hatch fmt --check
     - name: type checking

--- a/src/aws_durable_execution_sdk_python_testing/checkpoint/processors/base.py
+++ b/src/aws_durable_execution_sdk_python_testing/checkpoint/processors/base.py
@@ -127,7 +127,7 @@ class OperationProcessor:
             else:
                 scheduled_timestamp = datetime.datetime.now(
                     tz=datetime.UTC
-                ) + timedelta(seconds=update.wait_options.seconds)
+                ) + timedelta(seconds=update.wait_options.wait_seconds)
             return WaitDetails(scheduled_timestamp=scheduled_timestamp)
         return None
 

--- a/src/aws_durable_execution_sdk_python_testing/checkpoint/processors/wait.py
+++ b/src/aws_durable_execution_sdk_python_testing/checkpoint/processors/wait.py
@@ -38,7 +38,9 @@ class WaitProcessor(OperationProcessor):
         """Process WAIT operation update with scheduler integration for timers."""
         match update.action:
             case OperationAction.START:
-                wait_seconds = update.wait_options.seconds if update.wait_options else 0
+                wait_seconds = (
+                    update.wait_options.wait_seconds if update.wait_options else 0
+                )
                 scheduled_timestamp = datetime.now(UTC) + timedelta(
                     seconds=wait_seconds
                 )

--- a/tests/checkpoint/processors/base_test.py
+++ b/tests/checkpoint/processors/base_test.py
@@ -323,7 +323,7 @@ def test_create_wait_details_with_current_operation():
     current_op = Mock()
     current_op.wait_details = WaitDetails(scheduled_timestamp=scheduled_time)
 
-    wait_options = WaitOptions(seconds=30)
+    wait_options = WaitOptions(wait_seconds=30)
     update = OperationUpdate(
         operation_id="test-id",
         operation_type=OperationType.WAIT,
@@ -339,7 +339,7 @@ def test_create_wait_details_with_current_operation():
 
 def test_create_wait_details_without_current_operation():
     processor = MockProcessor()
-    wait_options = WaitOptions(seconds=30)
+    wait_options = WaitOptions(wait_seconds=30)
     update = OperationUpdate(
         operation_id="test-id",
         operation_type=OperationType.WAIT,

--- a/tests/checkpoint/processors/wait_test.py
+++ b/tests/checkpoint/processors/wait_test.py
@@ -50,7 +50,7 @@ def test_process_start_action():
     notifier = MockNotifier()
     execution_arn = "arn:aws:states:us-east-1:123456789012:execution:test"
 
-    wait_options = WaitOptions(seconds=30)
+    wait_options = WaitOptions(wait_seconds=30)
     update = OperationUpdate(
         operation_id="wait-123",
         operation_type=OperationType.WAIT,
@@ -99,7 +99,7 @@ def test_process_start_action_with_zero_seconds():
     notifier = MockNotifier()
     execution_arn = "arn:aws:states:us-east-1:123456789012:execution:test"
 
-    wait_options = WaitOptions(seconds=0)
+    wait_options = WaitOptions(wait_seconds=0)
     update = OperationUpdate(
         operation_id="wait-123",
         operation_type=OperationType.WAIT,
@@ -122,7 +122,7 @@ def test_process_start_action_with_parent_id():
     notifier = MockNotifier()
     execution_arn = "arn:aws:states:us-east-1:123456789012:execution:test"
 
-    wait_options = WaitOptions(seconds=15)
+    wait_options = WaitOptions(wait_seconds=15)
     update = OperationUpdate(
         operation_id="wait-123",
         operation_type=OperationType.WAIT,
@@ -142,7 +142,7 @@ def test_process_start_action_with_sub_type():
     notifier = MockNotifier()
     execution_arn = "arn:aws:states:us-east-1:123456789012:execution:test"
 
-    wait_options = WaitOptions(seconds=15)
+    wait_options = WaitOptions(wait_seconds=15)
     update = OperationUpdate(
         operation_id="wait-123",
         operation_type=OperationType.WAIT,
@@ -257,7 +257,7 @@ def test_wait_details_created_correctly():
     notifier = MockNotifier()
     execution_arn = "arn:aws:states:us-east-1:123456789012:execution:test"
 
-    wait_options = WaitOptions(seconds=60)
+    wait_options = WaitOptions(wait_seconds=60)
     update = OperationUpdate(
         operation_id="wait-123",
         operation_type=OperationType.WAIT,
@@ -277,7 +277,7 @@ def test_no_completed_or_failed_calls():
     notifier = MockNotifier()
     execution_arn = "arn:aws:states:us-east-1:123456789012:execution:test"
 
-    wait_options = WaitOptions(seconds=30)
+    wait_options = WaitOptions(wait_seconds=30)
     update = OperationUpdate(
         operation_id="wait-123",
         operation_type=OperationType.WAIT,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Updating `WaitOptions` to use `wait_seconds` instead of `seconds` to match the API spec.

## Dependencies
If this PR requires testing against a specific branch of the Python Language SDK (e.g., for unreleased changes), uncomment and specify the branch below. Otherwise, leave commented to use the main branch.

PYTHON_LANGUAGE_SDK_BRANCH: fix-wait-deserialization

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.