### PR TITLE
chore: update CLI to accept log level as string

### DIFF
--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import logging
 import os
 import sys
 from io import StringIO
@@ -24,7 +25,7 @@ def test_cli_config_has_correct_default_values() -> None:
 
     assert config.host == "0.0.0.0"  # noqa: S104
     assert config.port == 5000
-    assert config.log_level == 20
+    assert config.log_level == logging.INFO
     assert config.lambda_endpoint == "http://127.0.0.1:3001"
     assert config.local_runner_endpoint == "http://0.0.0.0:5000"
     assert config.local_runner_region == "us-west-2"
@@ -38,7 +39,7 @@ def test_cli_config_from_environment_uses_defaults_when_no_env_vars() -> None:
 
         assert config.host == "0.0.0.0"  # noqa: S104
         assert config.port == 5000
-        assert config.log_level == 20
+        assert config.log_level == logging.INFO
         assert config.lambda_endpoint == "http://127.0.0.1:3001"
         assert config.local_runner_endpoint == "http://0.0.0.0:5000"
         assert config.local_runner_region == "us-west-2"
@@ -50,7 +51,7 @@ def test_cli_config_from_environment_uses_all_env_vars_when_set() -> None:
     env_vars = {
         "AWS_DEX_HOST": "127.0.0.1",
         "AWS_DEX_PORT": "8080",
-        "AWS_DEX_LOG_LEVEL": "10",
+        "AWS_DEX_LOG_LEVEL": "DEBUG",
         "AWS_DEX_LAMBDA_ENDPOINT": "http://localhost:4000",
         "AWS_DEX_LOCAL_RUNNER_ENDPOINT": "http://localhost:8080",
         "AWS_DEX_LOCAL_RUNNER_REGION": "us-east-1",
@@ -62,7 +63,7 @@ def test_cli_config_from_environment_uses_all_env_vars_when_set() -> None:
 
         assert config.host == "127.0.0.1"
         assert config.port == 8080
-        assert config.log_level == 10
+        assert config.log_level == logging.DEBUG
         assert config.lambda_endpoint == "http://localhost:4000"
         assert config.local_runner_endpoint == "http://localhost:8080"
         assert config.local_runner_region == "us-east-1"
@@ -82,7 +83,7 @@ def test_cli_config_from_environment_uses_partial_env_vars_with_defaults() -> No
         assert config.host == "192.168.1.1"
         assert config.port == 9000
         # Other values should be defaults
-        assert config.log_level == 20
+        assert config.log_level == logging.INFO
         assert config.lambda_endpoint == "http://127.0.0.1:3001"
 
 
@@ -173,7 +174,7 @@ def test_start_server_command_parses_arguments_correctly() -> None:
                 "--port",
                 "8080",
                 "--log-level",
-                "10",
+                "DEBUG",
                 "--lambda-endpoint",
                 "http://localhost:4000",
                 "--local-runner-endpoint",
@@ -303,7 +304,7 @@ def test_logging_configuration_uses_specified_log_level() -> None:
     with patch("logging.basicConfig") as mock_basic_config:
         with patch("sys.stdout", new_callable=StringIO):
             with patch.object(app, "start_server_command", return_value=0):
-                app.run(["start-server", "--log-level", "10"])
+                app.run(["start-server", "--log-level", "DEBUG"])
 
                 mock_basic_config.assert_called_once()
                 call_args = mock_basic_config.call_args
@@ -348,7 +349,7 @@ def test_start_server_command_works_with_mocked_dependencies() -> None:
                 "--port",
                 "8080",
                 "--log-level",
-                "10",
+                "DEBUG",
             ]
         )
 
@@ -359,7 +360,7 @@ def test_start_server_command_works_with_mocked_dependencies() -> None:
         call_args = mock_web_runner.call_args[0][0]  # First positional argument
         assert call_args.web_service.host == "127.0.0.1"
         assert call_args.web_service.port == 8080
-        assert call_args.web_service.log_level == 10
+        assert call_args.web_service.log_level == "DEBUG"
 
 
 def test_start_server_command_handles_server_startup_errors() -> None:
@@ -398,7 +399,7 @@ def test_start_server_command_creates_correct_web_runner_config() -> None:
                 "--port",
                 "9000",
                 "--log-level",
-                "30",
+                "WARNING",
                 "--lambda-endpoint",
                 "http://custom-lambda:4000",
                 "--local-runner-endpoint",
@@ -419,7 +420,7 @@ def test_start_server_command_creates_correct_web_runner_config() -> None:
         # Verify web service configuration
         assert config.web_service.host == "192.168.1.100"
         assert config.web_service.port == 9000
-        assert config.web_service.log_level == 30
+        assert config.web_service.log_level == "WARNING"
 
         # Verify Lambda service configuration
         assert config.lambda_endpoint == "http://custom-lambda:4000"

--- a/tests/runner_web_test.py
+++ b/tests/runner_web_test.py
@@ -705,7 +705,7 @@ def test_should_pass_correct_configuration_to_web_server():
     """Test that WebServer receives correct configuration from WebRunnerConfig."""
     # Arrange
     web_config = WebServiceConfig(
-        host="custom-host", port=9999, log_level=30, max_request_size=2048
+        host="custom-host", port=9999, log_level="WARNING", max_request_size=2048
     )
     runner_config = WebRunnerConfig(web_service=web_config)
     runner = WebRunner(runner_config)
@@ -734,7 +734,7 @@ def test_should_pass_correct_configuration_to_web_server():
         assert passed_config == web_config
         assert passed_config.host == "custom-host"
         assert passed_config.port == 9999
-        assert passed_config.log_level == 30
+        assert passed_config.log_level == "WARNING"
         assert passed_config.max_request_size == 2048
 
         # Cleanup
@@ -1284,7 +1284,7 @@ def test_should_integrate_with_cli_start_server_command():
                 "--port",
                 "7777",
                 "--log-level",
-                "30",
+                "WARNING",
                 "--lambda-endpoint",
                 "http://integration-lambda:4000",
                 "--local-runner-endpoint",
@@ -1306,7 +1306,7 @@ def test_should_integrate_with_cli_start_server_command():
         # Verify web service configuration
         assert config.web_service.host == "integration-host"
         assert config.web_service.port == 7777
-        assert config.web_service.log_level == 30
+        assert config.web_service.log_level == "WARNING"
 
         # Verify Lambda service configuration
         assert config.lambda_endpoint == "http://integration-lambda:4000"
@@ -1430,7 +1430,7 @@ def test_should_preserve_cli_configuration_through_web_runner():
                 "--port",
                 "9999",
                 "--log-level",
-                "40",  # ERROR level
+                "ERROR",  # ERROR level
                 "--lambda-endpoint",
                 "http://config-lambda:5000",
                 "--local-runner-endpoint",
@@ -1452,7 +1452,7 @@ def test_should_preserve_cli_configuration_through_web_runner():
         # Verify web service configuration
         assert config.web_service.host == "config-test-host"
         assert config.web_service.port == 9999
-        assert config.web_service.log_level == 40
+        assert config.web_service.log_level == "ERROR"
 
         # Verify Lambda service configuration
         assert config.lambda_endpoint == "http://config-lambda:5000"
@@ -1472,7 +1472,7 @@ def test_should_handle_environment_variable_integration():
     env_vars = {
         "AWS_DEX_HOST": "env-host",
         "AWS_DEX_PORT": "8888",
-        "AWS_DEX_LOG_LEVEL": "50",  # CRITICAL level
+        "AWS_DEX_LOG_LEVEL": "CRITICAL",  # CRITICAL level
         "AWS_DEX_LAMBDA_ENDPOINT": "http://env-lambda:6000",
         "AWS_DEX_LOCAL_RUNNER_ENDPOINT": "http://env-runner:7000",
         "AWS_DEX_LOCAL_RUNNER_REGION": "sa-east-1",
@@ -1505,7 +1505,7 @@ def test_should_handle_environment_variable_integration():
             # Verify environment variables were used
             assert config.web_service.host == "env-host"
             assert config.web_service.port == 8888
-            assert config.web_service.log_level == 50
+            assert config.web_service.log_level == "CRITICAL"
             assert config.lambda_endpoint == "http://env-lambda:6000"
             assert config.local_runner_endpoint == "http://env-runner:7000"
             assert config.local_runner_region == "sa-east-1"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Updating the CLI for the server to accept the log level as a string instead of an int.

## Dependencies
If this PR requires testing against a specific branch of the Python Language SDK (e.g., for unreleased changes), uncomment and specify the branch below. Otherwise, leave commented to use the main branch.

<!-- PYTHON_LANGUAGE_SDK_BRANCH: main -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
