### PR TITLE
fix: parse bytes for callback operations

### DIFF
--- a/src/aws_durable_execution_sdk_python_testing/model.py
+++ b/src/aws_durable_execution_sdk_python_testing/model.py
@@ -1386,13 +1386,13 @@ class SendDurableExecutionCallbackFailureRequest:
     error: ErrorObject | None = None
 
     @classmethod
-    def from_dict(cls, data: dict) -> SendDurableExecutionCallbackFailureRequest:
-        error = None
-        if error_data := data.get("Error"):
-            error = ErrorObject.from_dict(error_data)
+    def from_dict(
+        cls, data: dict, callback_id: str
+    ) -> SendDurableExecutionCallbackFailureRequest:
+        error = ErrorObject.from_dict(data) if data else None
 
         return cls(
-            callback_id=data["CallbackId"],
+            callback_id=callback_id,
             error=error,
         )
 

--- a/src/aws_durable_execution_sdk_python_testing/web/routes.py
+++ b/src/aws_durable_execution_sdk_python_testing/web/routes.py
@@ -401,7 +401,12 @@ class ListDurableExecutionsByFunctionRoute(Route):
 
 
 @dataclass(frozen=True)
-class CallbackSuccessRoute(Route):
+class BytesPayloadRoute(Route):
+    """Base class for routes that handle raw bytes payloads instead of JSON."""
+
+
+@dataclass(frozen=True)
+class CallbackSuccessRoute(BytesPayloadRoute):
     """Route: POST /2025-12-01/durable-execution-callbacks/{callback_id}/succeed"""
 
     callback_id: str
@@ -444,7 +449,7 @@ class CallbackSuccessRoute(Route):
 
 
 @dataclass(frozen=True)
-class CallbackFailureRoute(Route):
+class CallbackFailureRoute(BytesPayloadRoute):
     """Route: POST /2025-12-01/durable-execution-callbacks/{callback_id}/fail"""
 
     callback_id: str

--- a/tests/model_test.py
+++ b/tests/model_test.py
@@ -798,32 +798,38 @@ def test_send_durable_execution_callback_success_response_creation():
 
 def test_send_durable_execution_callback_failure_request_serialization():
     """Test SendDurableExecutionCallbackFailureRequest from_dict/to_dict round-trip."""
-    data = {
-        "CallbackId": "callback-123",
-        "Error": {"ErrorMessage": "callback failed"},
-    }
+    data = {"ErrorMessage": "callback failed"}
 
-    request_obj = SendDurableExecutionCallbackFailureRequest.from_dict(data)
+    request_obj = SendDurableExecutionCallbackFailureRequest.from_dict(
+        data, "callback-123"
+    )
     assert request_obj.callback_id == "callback-123"
     assert request_obj.error.message == "callback failed"
 
     result_data = request_obj.to_dict()
-    assert result_data == data
+    expected_data = {
+        "CallbackId": "callback-123",
+        "Error": {"ErrorMessage": "callback failed"},
+    }
+    assert result_data == expected_data
 
     # Test round-trip
-    round_trip = SendDurableExecutionCallbackFailureRequest.from_dict(result_data)
+    round_trip = SendDurableExecutionCallbackFailureRequest.from_dict(
+        result_data.get("Error", {}), result_data["CallbackId"]
+    )
     assert round_trip == request_obj
 
 
 def test_send_durable_execution_callback_failure_request_minimal():
     """Test SendDurableExecutionCallbackFailureRequest with only required fields."""
-    data = {"CallbackId": "callback-123"}
 
-    request_obj = SendDurableExecutionCallbackFailureRequest.from_dict(data)
+    request_obj = SendDurableExecutionCallbackFailureRequest.from_dict(
+        {}, "callback-123"
+    )
     assert request_obj.error is None
 
     result_data = request_obj.to_dict()
-    assert result_data == data
+    assert result_data == {"CallbackId": "callback-123"}
 
 
 def test_send_durable_execution_callback_failure_response_creation():

--- a/tests/web/models_test.py
+++ b/tests/web/models_test.py
@@ -22,7 +22,6 @@ from aws_durable_execution_sdk_python_testing.web.models import (
     HTTPRequest,
     HTTPResponse,
     OperationHandler,
-    parse_json_body,
 )
 from aws_durable_execution_sdk_python_testing.web.routes import Route
 
@@ -78,53 +77,6 @@ def test_http_response_immutable() -> None:
     # Should not be able to modify fields
     with pytest.raises(AttributeError):
         response.status_code = 404  # type: ignore
-
-
-def test_parse_json_body_valid_json() -> None:
-    """Test parsing valid JSON from request body."""
-    test_data = {"key": "value", "number": 42}
-
-    path = Route.from_string("/test")
-    request = HTTPRequest(
-        method="POST",
-        path=path,
-        headers={"Content-Type": "application/json"},
-        query_params={},
-        body=test_data,
-    )
-
-    result = parse_json_body(request)
-    assert result == test_data
-
-
-def test_parse_json_body_empty_body() -> None:
-    """Test parsing JSON from empty request body raises ValueError."""
-    path = Route.from_string("/test")
-    request = HTTPRequest(
-        method="POST", path=path, headers={}, query_params={}, body={}
-    )
-
-    with pytest.raises(
-        InvalidParameterValueException, match="Request body is required"
-    ):
-        parse_json_body(request)
-
-
-def test_parse_json_body_with_dict_body() -> None:
-    """Test that parse_json_body now just returns the dict body directly."""
-    test_data = {"key": "value", "number": 42}
-    path = Route.from_string("/test")
-    request = HTTPRequest(
-        method="POST",
-        path=path,
-        headers={"Content-Type": "application/json"},
-        query_params={},
-        body=test_data,
-    )
-
-    result = parse_json_body(request)
-    assert result == test_data
-    assert result is request.body  # Should return the same dict object
 
 
 def test_http_response_json_basic() -> None:
@@ -418,6 +370,7 @@ def test_http_request_from_bytes_preserves_field_names() -> None:
     request = HTTPRequest.from_bytes(body_bytes=body_bytes)
 
     # Field names should be preserved as-is
+    assert isinstance(request.body, dict)
     assert "ExecutionName" in request.body
     assert "FunctionName" in request.body
     assert request.body["ExecutionName"] == "test-execution"


### PR DESCRIPTION
*Issue #, if available:*
#42 - pre-req for hitting it through web server.

*Description of changes:*
Updating the request handling for `SendDurableExecutionCallbackSuccess` and `SendDurableExecutionCallbackFailure`. Both of these requests accept their `Result` and `Error` fields as `@httpPayload`, meaning they get serialized to a raw bytes body instead of JSON.

I'm following the same convention as how we deserialize `.from_dict()` for checkpoints where we pass the execution arn from the path to `.from_dict()` - except using the callback id.

I tested it by using the AWS CLI and sending requests to the local server and ensuring that the requests were being deserialized properly.

Success:
```
aws lambda send-durable-execution-callback-success --callback-id my-callback --endpoint-url "http://localhost:5000" --result "$(echo -n 'hello world' | base64)"

...
DEBUG - Callback my-callback succeeded with result: hello world
```

Failure:
```
aws lambda send-durable-execution-callback-failure \
  --callback-id "my-callback" \       
  --error '{
    "ErrorType": "TimeoutError",
    "ErrorMessage": "Task failed due to timeout",
    "ErrorData": "Additional error context",
    "StackTrace": ["line 1", "line 2"]
  }' \
  --endpoint-url http://localhost:5000

...
DEBUG - Callback my-callback failed with error: ErrorObject(message='Task failed due to timeout', type='TimeoutError', data='Additional error context', stack_trace=['line 1', 'line 2'])
```


## Dependencies
If this PR requires testing against a specific branch of the Python Language SDK (e.g., for unreleased changes), uncomment and specify the branch below. Otherwise, leave commented to use the main branch.

<!-- PYTHON_LANGUAGE_SDK_BRANCH: main -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
