### PR TITLE
fix: update branch in default pr template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,6 +5,6 @@
 ## Dependencies
 If this PR requires testing against a specific branch of the Python Language SDK (e.g., for unreleased changes), uncomment and specify the branch below. Otherwise, leave commented to use the main branch.
 
-<!-- PYTHON_LANGUAGE_SDK_BRANCH: branch-name -->
+<!-- PYTHON_LANGUAGE_SDK_BRANCH: main -->
 
 By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
The PR template needs to default to `main` for the python SDK branch, otherwise people have to manually update that part of the description every time.

## Dependencies
If this PR requires testing against a specific branch of the Python Language SDK (e.g., for unreleased changes), uncomment and specify the branch below. Otherwise, leave commented to use the main branch.

<!-- PYTHON_LANGUAGE_SDK_BRANCH: main -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
