### PR TITLE
feat(testing-sdk): add dual-mode integration testing infrastructure

### DIFF
--- a/.github/workflows/deploy-examples.yml
+++ b/.github/workflows/deploy-examples.yml
@@ -71,6 +71,7 @@ jobs:
       run: hatch run examples:build
 
     - name: Deploy Lambda function - ${{ matrix.example.name }}
+      id: deploy
       env:
         AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
         LAMBDA_ENDPOINT: ${{ secrets.LAMBDA_ENDPOINT_BETA }}
@@ -88,13 +89,35 @@ jobs:
         echo "Deploying ${{ matrix.example.name }} as $FUNCTION_NAME"
         hatch run examples:deploy "${{ matrix.example.name }}" --function-name "$FUNCTION_NAME"
         
-        # $LATEST is also a qualified version        
-        QUALIFIED_FUNCTION_NAME="$FUNCTION_NAME:\$LATEST"
+        # $LATEST is also a qualified version
+        QUALIFIED_FUNCTION_NAME="${FUNCTION_NAME}:\$LATEST"
         
         # Store both names for later steps
         echo "FUNCTION_NAME=$FUNCTION_NAME" >> $GITHUB_ENV
         echo "QUALIFIED_FUNCTION_NAME=$QUALIFIED_FUNCTION_NAME" >> $GITHUB_ENV
         echo "VERSION=$VERSION" >> $GITHUB_ENV
+        echo "DEPLOYED_FUNCTION_NAME=$FUNCTION_NAME" >> $GITHUB_OUTPUT
+        echo "QUALIFIED_FUNCTION_NAME=$QUALIFIED_FUNCTION_NAME" >> $GITHUB_OUTPUT
+
+    - name: Run Integration Tests - ${{ matrix.example.name }}
+      env:
+        AWS_REGION: ${{ env.AWS_REGION }}
+        LAMBDA_ENDPOINT: ${{ secrets.LAMBDA_ENDPOINT_BETA }}
+        QUALIFIED_FUNCTION_NAME: ${{ env.QUALIFIED_FUNCTION_NAME }}
+        LAMBDA_FUNCTION_TEST_NAME: ${{ matrix.example.name }}
+      run: |
+        echo "Running integration tests for ${{ matrix.example.name }}"
+        echo "Function name: ${{ steps.deploy.outputs.DEPLOYED_FUNCTION_NAME }}"
+        echo "Qualified function name: ${QUALIFIED_FUNCTION_NAME}"
+        echo "AWS Region: ${AWS_REGION}"
+        echo "Lambda Endpoint: ${LAMBDA_ENDPOINT}"
+        
+        # Convert example name to test name: "Hello World" -> "test_hello_world"
+        TEST_NAME="test_$(echo "${{ matrix.example.name }}" | tr '[:upper:]' '[:lower:]' | tr ' ' '_')"
+        echo "Test name: ${TEST_NAME}"
+        
+        # Run integration tests
+        hatch run test:examples-integration
 
     - name: Invoke Lambda function - ${{ matrix.example.name }}
       env:

--- a/examples/examples-catalog.json
+++ b/examples/examples-catalog.json
@@ -110,6 +110,50 @@
         "ExecutionTimeout": 300
       },
       "path": "./src/map_operations.py"
+    },
+    {
+      "name": "Block Example",
+      "description": "Nested child contexts demonstrating block operations",
+      "handler": "block_example.handler",
+      "integration": true,
+      "durableConfig": {
+        "RetentionPeriodInDays": 7,
+        "ExecutionTimeout": 300
+      },
+      "path": "./src/block_example.py"
+    },
+    {
+      "name": "Logger Example",
+      "description": "Demonstrating logger usage and enrichment in DurableContext",
+      "handler": "logger_example.handler",
+      "integration": true,
+      "durableConfig": {
+        "RetentionPeriodInDays": 7,
+        "ExecutionTimeout": 300
+      },
+      "path": "./src/logger_example.py"
+    },
+    {
+      "name": "Steps with Retry",
+      "description": "Multiple steps with retry logic in a polling pattern",
+      "handler": "steps_with_retry.handler",
+      "integration": true,
+      "durableConfig": {
+        "RetentionPeriodInDays": 7,
+        "ExecutionTimeout": 300
+      },
+      "path": "./src/steps_with_retry.py"
+    },
+    {
+      "name": "Wait for Condition",
+      "description": "Polling pattern that waits for a condition to be met",
+      "handler": "wait_for_condition.handler",
+      "integration": true,
+      "durableConfig": {
+        "RetentionPeriodInDays": 7,
+        "ExecutionTimeout": 300
+      },
+      "path": "./src/wait_for_condition.py"
     }
   ]
 }

--- a/examples/src/block_example.py
+++ b/examples/src/block_example.py
@@ -1,0 +1,46 @@
+"""Example demonstrating nested child contexts (blocks)."""
+
+from typing import Any
+
+from aws_durable_execution_sdk_python.context import (
+    DurableContext,
+    durable_with_child_context,
+)
+from aws_durable_execution_sdk_python.execution import durable_execution
+
+
+@durable_with_child_context
+def nested_block(ctx: DurableContext) -> str:
+    """Nested block with its own child context."""
+    # Wait in the nested block
+    ctx.wait(seconds=1)
+    return "nested block result"
+
+
+@durable_with_child_context
+def parent_block(ctx: DurableContext) -> dict[str, str]:
+    """Parent block with nested operations."""
+    # Nested step
+    nested_result: str = ctx.step(
+        lambda _: "nested step result",
+        name="nested_step",
+    )
+
+    # Nested block with its own child context
+    nested_block_result: str = ctx.run_in_child_context(nested_block())
+
+    return {
+        "nestedStep": nested_result,
+        "nestedBlock": nested_block_result,
+    }
+
+
+@durable_execution
+def handler(_event: Any, context: DurableContext) -> dict[str, str]:
+    """Handler demonstrating nested child contexts."""
+    # Run parent block which contains nested operations
+    result: dict[str, str] = context.run_in_child_context(
+        parent_block(), name="parent_block"
+    )
+
+    return result

--- a/examples/src/logger_example.py
+++ b/examples/src/logger_example.py
@@ -1,0 +1,50 @@
+"""Example demonstrating logger usage in DurableContext."""
+
+from typing import Any
+
+from aws_durable_execution_sdk_python.context import (
+    DurableContext,
+    durable_with_child_context,
+)
+from aws_durable_execution_sdk_python.execution import durable_execution
+
+
+@durable_with_child_context
+def child_workflow(ctx: DurableContext) -> str:
+    """Child workflow with its own logging context."""
+    # Child context logger has step_id populated with child context ID
+    ctx.logger.info("Running in child context")
+
+    # Step in child context has nested step ID
+    child_result: str = ctx.step(
+        lambda _: "child-processed",
+        name="child_step",
+    )
+
+    ctx.logger.info("Child workflow completed", extra={"result": child_result})
+
+    return child_result
+
+
+@durable_execution
+def handler(event: Any, context: DurableContext) -> str:
+    """Handler demonstrating logger usage."""
+    # Top-level context logger: no step_id field
+    context.logger.info("Starting workflow", extra={"eventId": event.get("id")})
+
+    # Logger in steps - gets enriched with step ID and attempt number
+    result1: str = context.step(
+        lambda _: "processed",
+        name="process_data",
+    )
+
+    context.logger.info("Step 1 completed", extra={"result": result1})
+
+    # Child contexts inherit the parent's logger and have their own step ID
+    result2: str = context.run_in_child_context(child_workflow(), name="child_workflow")
+
+    context.logger.info(
+        "Workflow completed", extra={"result1": result1, "result2": result2}
+    )
+
+    return f"{result1}-{result2}"

--- a/examples/src/map_operations.py
+++ b/examples/src/map_operations.py
@@ -1,3 +1,5 @@
+"""Example demonstrating map-like operations for processing collections durably."""
+
 from typing import Any
 
 from aws_durable_execution_sdk_python.context import DurableContext
@@ -9,8 +11,8 @@ def square(x: int) -> int:
 
 
 @durable_execution
-def handler(_event: Any, context: DurableContext) -> str:
-    # Process a list of items using map-like operations
+def handler(_event: Any, context: DurableContext) -> list[int]:
+    """Process a list of items using map-like operations."""
     items = [1, 2, 3, 4, 5]
 
     # Process each item as a separate durable step
@@ -19,4 +21,4 @@ def handler(_event: Any, context: DurableContext) -> str:
         result = context.step(lambda _, x=item: square(x), name=f"square_{i}")
         results.append(result)
 
-    return f"Squared results: {results}"
+    return results

--- a/examples/src/parallel.py
+++ b/examples/src/parallel.py
@@ -1,3 +1,5 @@
+"""Example demonstrating parallel-like operations for concurrent execution."""
+
 from typing import Any
 
 from aws_durable_execution_sdk_python.context import DurableContext
@@ -5,11 +7,11 @@ from aws_durable_execution_sdk_python.execution import durable_execution
 
 
 @durable_execution
-def handler(_event: Any, context: DurableContext) -> str:
-    # Execute multiple operations in parallel
+def handler(_event: Any, context: DurableContext) -> list[str]:
+    # Execute multiple operations
     task1 = context.step(lambda _: "Task 1 complete", name="task1")
     task2 = context.step(lambda _: "Task 2 complete", name="task2")
     task3 = context.step(lambda _: "Task 3 complete", name="task3")
 
     # All tasks execute concurrently and results are collected
-    return f"Results: {task1}, {task2}, {task3}"
+    return [task1, task2, task3]

--- a/examples/src/step_with_retry.py
+++ b/examples/src/step_with_retry.py
@@ -15,7 +15,9 @@ from aws_durable_execution_sdk_python.retries import (
 
 
 @durable_step
-def unreliable_operation(_step_context: StepContext) -> str:
+def unreliable_operation(
+    _step_context: StepContext,
+) -> str:
     failure_threshold = 0.5
     if random() > failure_threshold:  # noqa: S311
         msg = "Random error occurred"

--- a/examples/src/steps_with_retry.py
+++ b/examples/src/steps_with_retry.py
@@ -1,0 +1,73 @@
+"""Example demonstrating multiple steps with retry logic."""
+
+from random import random
+from typing import Any
+
+from aws_durable_execution_sdk_python.config import StepConfig
+from aws_durable_execution_sdk_python.context import DurableContext
+from aws_durable_execution_sdk_python.execution import durable_execution
+from aws_durable_execution_sdk_python.retries import (
+    RetryStrategyConfig,
+    create_retry_strategy,
+)
+
+
+def simulated_get_item(name: str) -> dict[str, Any] | None:
+    """Simulate getting an item that may fail randomly."""
+    # Fail 50% of the time
+    if random() < 0.5:  # noqa: S311
+        msg = "Random failure"
+        raise RuntimeError(msg)
+
+    # Simulate finding item after some attempts
+    if random() > 0.3:  # noqa: S311
+        return {"id": name, "data": "item data"}
+
+    return None
+
+
+@durable_execution
+def handler(event: Any, context: DurableContext) -> dict[str, Any]:
+    """Handler demonstrating polling with retry logic."""
+    name = event.get("name", "test-item")
+
+    # Retry configuration for steps
+    retry_config = RetryStrategyConfig(
+        max_attempts=5,
+        retryable_error_types=[RuntimeError],
+    )
+
+    step_config = StepConfig(create_retry_strategy(retry_config))
+
+    item = None
+    poll_count = 0
+    max_polls = 5
+
+    try:
+        while poll_count < max_polls:
+            poll_count += 1
+
+            # Try to get the item with retry
+            get_response = context.step(
+                lambda _, n=name: simulated_get_item(n),
+                name=f"get_item_poll_{poll_count}",
+                config=step_config,
+            )
+
+            # Did we find the item?
+            if get_response:
+                item = get_response
+                break
+
+            # Wait 1 second until next poll
+            context.wait(seconds=1)
+
+    except RuntimeError as e:
+        # Retries exhausted
+        return {"error": "DDB Retries Exhausted", "message": str(e)}
+
+    if not item:
+        return {"error": "Item Not Found"}
+
+    # We found the item!
+    return {"success": True, "item": item, "pollsRequired": poll_count}

--- a/examples/src/wait_for_condition.py
+++ b/examples/src/wait_for_condition.py
@@ -1,0 +1,33 @@
+"""Example demonstrating wait-for-condition pattern."""
+
+from typing import Any
+
+from aws_durable_execution_sdk_python.context import DurableContext
+from aws_durable_execution_sdk_python.execution import durable_execution
+
+
+@durable_execution
+def handler(_event: Any, context: DurableContext) -> int:
+    """Handler demonstrating wait-for-condition pattern."""
+    state = 0
+    attempt = 0
+    max_attempts = 5
+
+    while attempt < max_attempts:
+        attempt += 1
+
+        # Execute step to update state
+        state = context.step(
+            lambda _, s=state: s + 1,
+            name=f"increment_state_{attempt}",
+        )
+
+        # Check condition
+        if state >= 3:
+            # Condition met, stop
+            break
+
+        # Wait before next attempt
+        context.wait(seconds=1)
+
+    return state

--- a/examples/template.yaml
+++ b/examples/template.yaml
@@ -1,4 +1,4 @@
-AWSTemplateFormatVersion: '2010-09-09'
+AWSTemplateFormatVersion: "2010-09-09"
 Transform: AWS::Serverless-2016-10-31
 Globals:
   Function:
@@ -64,7 +64,8 @@ Resources:
     Properties:
       CodeUri: build/
       Handler: callback.handler
-      Description: Basic usage of context.create_callback() to create a callback for
+      Description:
+        Basic usage of context.create_callback() to create a callback for
         external systems
       DurableConfig:
         RetentionPeriodInDays: 7
@@ -74,7 +75,8 @@ Resources:
     Properties:
       CodeUri: build/
       Handler: wait_for_callback.handler
-      Description: Usage of context.wait_for_callback() to wait for external system
+      Description:
+        Usage of context.wait_for_callback() to wait for external system
         responses
       DurableConfig:
         RetentionPeriodInDays: 7
@@ -84,7 +86,8 @@ Resources:
     Properties:
       CodeUri: build/
       Handler: run_in_child_context.handler
-      Description: Usage of context.run_in_child_context() to execute operations in
+      Description:
+        Usage of context.run_in_child_context() to execute operations in
         isolated contexts
       DurableConfig:
         RetentionPeriodInDays: 7
@@ -104,6 +107,42 @@ Resources:
       CodeUri: build/
       Handler: map_operations.handler
       Description: Processing collections using map-like durable operations
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  BlockExample:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: build/
+      Handler: block_example.handler
+      Description: Nested child contexts demonstrating block operations
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  LoggerExample:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: build/
+      Handler: logger_example.handler
+      Description: Demonstrating logger usage and enrichment in DurableContext
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  StepsWithRetry:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: build/
+      Handler: steps_with_retry.handler
+      Description: Multiple steps with retry logic in a polling pattern
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  WaitForCondition:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: build/
+      Handler: wait_for_condition.handler
+      Description: Polling pattern that waits for a condition to be met
       DurableConfig:
         RetentionPeriodInDays: 7
         ExecutionTimeout: 300

--- a/examples/test/README.md
+++ b/examples/test/README.md
@@ -1,0 +1,119 @@
+# Integration Tests for Python Durable Execution SDK
+
+This directory contains integration tests for the Python Durable Execution SDK examples. Tests can run in two modes using pytest fixtures.
+
+## Test Modes
+
+### Local Mode (Default)
+Tests run against the in-memory `DurableFunctionTestRunner`:
+- ✅ Fast execution (seconds)
+- ✅ No AWS credentials needed
+- ✅ Perfect for development
+- ✅ Validates local runner behavior
+
+```bash
+# Run all example tests locally (default)
+hatch run test:examples
+
+# Run with explicit mode flag
+pytest --runner-mode=local -m example examples/test/
+
+# Run specific test
+pytest --runner-mode=local -k test_hello_world examples/test/
+```
+
+### Cloud Mode (Integration)
+Tests run against actual AWS Lambda functions using `DurableFunctionCloudTestRunner`:
+- ✅ Validates cloud deployment
+- ✅ Tests real Lambda execution
+- ✅ Verifies end-to-end behavior
+- ⚠️ Requires deployed functions
+
+```bash
+# Deploy function first
+hatch run examples:deploy "hello world" --function-name HelloWorld-Test
+
+# Set environment variables for cloud testing
+export AWS_REGION=us-west-2
+export LAMBDA_ENDPOINT=https://lambda.us-west-2.amazonaws.com
+export QUALIFIED_FUNCTION_NAME="HelloWorld-Test:\$LATEST"
+export LAMBDA_FUNCTION_TEST_NAME="hello world"
+
+# Run tests
+pytest --runner-mode=cloud -k test_hello_world examples/test/
+
+# Or using hatch
+hatch run test:examples-integration -k test_hello_world
+```
+
+## Writing Tests
+
+Use the `durable_runner` pytest fixture with the `@pytest.mark.durable_execution` marker:
+
+```python
+import pytest
+from aws_durable_execution_sdk_python.execution import InvocationStatus
+from examples.src import my_example
+
+
+@pytest.mark.example
+@pytest.mark.durable_execution(
+    handler=my_example.handler,
+    lambda_function_name="my example",
+)
+def test_my_example(durable_runner):
+    """Test my example in both local and cloud modes."""
+    with durable_runner:
+        result = durable_runner.run(input={"test": "data"}, timeout=10)
+    
+    # Assertions work in both modes
+    assert result.status == InvocationStatus.SUCCEEDED
+    assert result.result == "expected output"
+    
+    # Optional mode-specific validations
+    if durable_runner.mode == "cloud":
+        # Cloud-specific assertions
+        pass
+```
+
+## Configuration
+
+### Environment Variables (Cloud Mode)
+- `AWS_REGION` - AWS region for Lambda invocation (default: us-west-2)
+- `LAMBDA_ENDPOINT` - Optional Lambda endpoint URL for testing
+- `QUALIFIED_FUNCTION_NAME` - Deployed Lambda function ARN or qualified name (required for cloud mode)
+- `LAMBDA_FUNCTION_TEST_NAME` - Lambda function name to match with test's `lambda_function_name` marker (required for cloud mode)
+
+### CLI Options
+- `--runner-mode` - Test mode: `local` (default) or `cloud`
+
+### Pytest Markers
+- `-m example` - Run only example tests
+- `-k test_name` - Run tests matching pattern
+
+## CI/CD Integration
+
+Tests automatically run in CI/CD after deployment:
+
+1. `deploy-examples.yml` deploys functions
+2. Integration tests run against deployed functions
+3. Results reported in GitHub Actions
+
+See `.github/workflows/deploy-examples.yml` for details.
+
+## Troubleshooting
+
+### Timeout errors
+**Problem**: `TimeoutError: Execution did not complete within 60s`
+
+**Solution**: Increase timeout in test:
+```python
+result = runner.run(input="test", timeout=120)  # Increase to 120s
+```
+
+### Import errors
+**Problem**: `ModuleNotFoundError: No module named 'aws_durable_execution_sdk_python_testing'`
+
+**Solution**: Install dependencies:
+```bash
+hatch run test:examples  # Installs dependencies automatically

--- a/examples/test/conftest.py
+++ b/examples/test/conftest.py
@@ -1,0 +1,231 @@
+"""Pytest configuration and fixtures for durable execution tests."""
+
+import contextlib
+import json
+import logging
+import os
+import sys
+from enum import StrEnum
+from pathlib import Path
+from typing import Any
+
+import pytest
+from aws_durable_execution_sdk_python.lambda_service import OperationPayload
+from aws_durable_execution_sdk_python.serdes import ExtendedTypeSerDes
+
+from aws_durable_execution_sdk_python_testing.runner import (
+    DurableFunctionCloudTestRunner,
+    DurableFunctionTestResult,
+    DurableFunctionTestRunner,
+)
+
+
+# Add examples/src to Python path for imports
+examples_src = Path(__file__).parent.parent / "src"
+if str(examples_src) not in sys.path:
+    sys.path.insert(0, str(examples_src))
+
+
+logger = logging.getLogger(__name__)
+
+
+def deserialize_operation_payload(
+    payload: OperationPayload | None, serdes: ExtendedTypeSerDes | None = None
+) -> Any:
+    """Deserialize an operation payload using the provided or default serializer.
+
+    This utility function helps test code deserialize operation results that are
+    returned as raw strings. It supports both the default ExtendedTypeSerDes and
+    custom serializers.
+
+    Args:
+        payload: The operation payload string to deserialize, or None.
+        serdes: Optional custom serializer. If None, uses ExtendedTypeSerDes.
+
+    Returns:
+        Deserialized result object, or None if payload is None.
+    """
+    if not payload:
+        return None
+
+    if serdes is None:
+        serdes = ExtendedTypeSerDes()
+
+    try:
+        return serdes.deserialize(payload)
+    except Exception:
+        # Fallback to plain JSON for backwards compatibility
+        return json.loads(payload)
+
+
+class RunnerMode(StrEnum):
+    """Runner mode for local or cloud execution."""
+
+    LOCAL = "local"
+    CLOUD = "cloud"
+
+
+def pytest_addoption(parser):
+    """Add custom command line options for test execution."""
+    parser.addoption(
+        "--runner-mode",
+        action="store",
+        default=RunnerMode.LOCAL,
+        choices=[RunnerMode.LOCAL, RunnerMode.CLOUD],
+        help="Test runner mode: local (in-memory) or cloud (deployed Lambda)",
+    )
+
+
+class TestRunnerAdapter:
+    """Adapter that provides consistent interface for both local and cloud runners.
+
+    This adapter encapsulates the differences between local and cloud test runners:
+    - Local runner: Requires context manager for resource cleanup (scheduler thread)
+    - Cloud runner: No resource cleanup needed (stateless boto3 client)
+
+    The adapter ensures proper resource management while providing a unified interface.
+    """
+
+    def __init__(
+        self,
+        runner: DurableFunctionTestRunner | DurableFunctionCloudTestRunner,
+        mode: str,
+    ):
+        """Initialize the adapter."""
+        self._runner: DurableFunctionTestRunner | DurableFunctionCloudTestRunner = (
+            runner
+        )
+        self._mode: str = mode
+
+    def run(
+        self,
+        input: str | None = None,  # noqa: A002
+        timeout: int = 60,
+    ) -> DurableFunctionTestResult:
+        """Execute the durable function and return results."""
+        return self._runner.run(input=input, timeout=timeout)
+
+    @property
+    def mode(self) -> str:
+        """Get the runner mode (local or cloud)."""
+        return self._mode
+
+    def __enter__(self):
+        """Context manager entry - only calls runner's __enter__ if it's a context manager."""
+        if isinstance(self._runner, contextlib.AbstractContextManager):
+            self._runner.__enter__()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Context manager exit - only calls runner's __exit__ if it's a context manager."""
+        if isinstance(self._runner, contextlib.AbstractContextManager):
+            return self._runner.__exit__(exc_type, exc_val, exc_tb)
+        return None
+
+
+@pytest.fixture
+def durable_runner(request):
+    """Pytest fixture that provides a test runner based on configuration.
+
+    Configuration for cloud mode:
+        Environment variables (required):
+            AWS_REGION: AWS region for Lambda invocation (default: us-west-2)
+            LAMBDA_ENDPOINT: Optional Lambda endpoint URL
+            PYTEST_FUNCTION_NAME_MAP: JSON mapping of example names to deployed function names
+        
+        CLI option:
+            --runner-mode=cloud (or local, default: local)
+        
+        Example:
+            AWS_REGION=us-west-2 \
+            LAMBDA_ENDPOINT=https://lambda.us-west-2.amazonaws.com \
+            PYTEST_FUNCTION_NAME_MAP='{"hello world":"HelloWorld:$LATEST"}' \
+            pytest --runner-mode=cloud -k test_hello_world
+
+    Usage in tests:
+        @pytest.mark.durable_execution(
+            handler=hello_world.handler,
+            lambda_function_name="hello world"
+        )
+        def test_hello_world(durable_runner):
+            with durable_runner:
+                result = durable_runner.run(input="test", timeout=10)
+            assert result.status == InvocationStatus.SUCCEEDED
+    """
+    # Get marker with test configuration
+    marker = request.node.get_closest_marker("durable_execution")
+    if not marker:
+        pytest.fail("Test must be marked with @pytest.mark.durable_execution")
+
+    handler: Any = marker.kwargs.get("handler")
+    lambda_function_name: str | None = marker.kwargs.get("lambda_function_name")
+
+    # Get runner mode from CLI option
+    runner_mode: str = request.config.getoption("--runner-mode")
+
+    logger.info("Running test in %s mode", runner_mode.upper())
+
+    # Create appropriate runner
+    if runner_mode == RunnerMode.CLOUD:
+        # Get deployed function name and AWS config from environment
+        deployed_name = _get_deployed_function_name(request, lambda_function_name)
+        region = os.environ.get("AWS_REGION", "us-west-2")
+        lambda_endpoint = os.environ.get("LAMBDA_ENDPOINT")
+
+        logger.info("Using AWS region: %s", region)
+
+        # Create cloud runner (no cleanup needed)
+        runner = DurableFunctionCloudTestRunner(
+            function_name=deployed_name,
+            region=region,
+            lambda_endpoint=lambda_endpoint,
+        )
+    else:
+        if not handler:
+            pytest.fail("handler is required for local mode tests")
+        # Create local runner (needs cleanup via context manager)
+        runner = DurableFunctionTestRunner(handler=handler)
+
+    # Wrap in adapter and use context manager for proper cleanup
+    with TestRunnerAdapter(runner, runner_mode) as adapter:
+        yield adapter
+
+
+def _get_deployed_function_name(
+    request: pytest.FixtureRequest,
+    lambda_function_name: str | None,
+) -> str:
+    """Get the deployed function name from environment variables.
+
+    Required environment variables:
+    - QUALIFIED_FUNCTION_NAME: The qualified function ARN (e.g., "MyFunction:$LATEST")
+    - LAMBDA_FUNCTION_TEST_NAME: The lambda function name to match against test markers
+
+    Tests are skipped if the test's lambda_function_name doesn't match LAMBDA_FUNCTION_TEST_NAME.
+    """
+    if not lambda_function_name:
+        pytest.fail("lambda_function_name is required for cloud mode tests")
+
+    # Get from environment variables
+    function_arn = os.environ.get("QUALIFIED_FUNCTION_NAME")
+    env_function_name = os.environ.get("LAMBDA_FUNCTION_TEST_NAME")
+
+    if not function_arn or not env_function_name:
+        pytest.fail(
+            "Cloud mode requires both QUALIFIED_FUNCTION_NAME and LAMBDA_FUNCTION_TEST_NAME environment variables\n"
+            'Example: QUALIFIED_FUNCTION_NAME="MyFunction:$LATEST" LAMBDA_FUNCTION_TEST_NAME="hello world" pytest --runner-mode=cloud'
+        )
+
+    # Check if this test matches the function name (case-insensitive)
+    if lambda_function_name.lower() == env_function_name.lower():
+        logger.info(
+            "Using function ARN: %s for lambda function: %s",
+            function_arn,
+            env_function_name,
+        )
+        return function_arn
+
+    # This test doesn't match the function name, skip it
+    pytest.skip(
+        f"Test '{lambda_function_name}' doesn't match LAMBDA_FUNCTION_TEST_NAME '{env_function_name}'"
+    )

--- a/examples/test/test_block_example.py
+++ b/examples/test/test_block_example.py
@@ -1,0 +1,104 @@
+"""Tests for block_example."""
+
+import pytest
+from aws_durable_execution_sdk_python.execution import InvocationStatus
+
+from src import block_example
+from test.conftest import deserialize_operation_payload
+
+
+def _get_all_operations(operations):
+    """Recursively get all operations including nested ones."""
+    all_ops = []
+    for op in operations:
+        all_ops.append(op)
+        if hasattr(op, "child_operations") and op.child_operations:
+            all_ops.extend(_get_all_operations(op.child_operations))
+    return all_ops
+
+
+@pytest.mark.example
+@pytest.mark.durable_execution(
+    handler=block_example.handler,
+    lambda_function_name="block example",
+)
+def test_block_example(durable_runner):
+    """Test block example with nested child contexts."""
+    with durable_runner:
+        result = durable_runner.run(input="test", timeout=10)
+
+    assert result.status is InvocationStatus.SUCCEEDED
+
+    # Verify the final result structure
+    assert deserialize_operation_payload(result.result) == {
+        "nestedStep": "nested step result",
+        "nestedBlock": "nested block result",
+    }
+
+    # Check for the parent block operation
+    parent_block_ops = [
+        op
+        for op in result.operations
+        if op.operation_type.value == "CONTEXT" and op.name == "parent_block"
+    ]
+    assert len(parent_block_ops) == 1
+    parent_block_op = parent_block_ops[0]
+
+    # Verify parent block result
+    assert deserialize_operation_payload(parent_block_op.result) == {
+        "nestedStep": "nested step result",
+        "nestedBlock": "nested block result",
+    }
+
+    # Verify parent block has 2 child operations
+    child_operations = parent_block_op.child_operations
+    assert len(child_operations) == 2
+
+    # First child should be a STEP with result "nested step result"
+    assert child_operations[0].operation_type.value == "STEP"
+    assert (
+        deserialize_operation_payload(child_operations[0].result)
+        == "nested step result"
+    )
+
+    # Second child should be a CONTEXT with result "nested block result"
+    assert child_operations[1].operation_type.value == "CONTEXT"
+    assert (
+        deserialize_operation_payload(child_operations[1].result)
+        == "nested block result"
+    )
+
+    # Check for nested step operation by name
+    nested_step_ops = [
+        op
+        for op in result.operations
+        if op.operation_type.value == "STEP" and op.name == "nested_step"
+    ]
+    # Note: nested_step is inside parent_block, so it won't be at top level
+    # We need to search in child operations
+    all_ops = _get_all_operations(result.operations)
+    nested_step_ops = [
+        op
+        for op in all_ops
+        if op.operation_type.value == "STEP" and op.name == "nested_step"
+    ]
+    assert len(nested_step_ops) == 1
+    assert (
+        deserialize_operation_payload(nested_step_ops[0].result) == "nested step result"
+    )
+
+    # Check for nested block operation by name
+    nested_block_ops = [
+        op
+        for op in all_ops
+        if op.operation_type.value == "CONTEXT" and op.name == "nested_block"
+    ]
+    assert len(nested_block_ops) == 1
+    assert (
+        deserialize_operation_payload(nested_block_ops[0].result)
+        == "nested block result"
+    )
+
+    # Verify wait operation exists within nested context
+    wait_ops = [op for op in all_ops if op.operation_type.value == "WAIT"]
+    assert len(wait_ops) >= 1

--- a/examples/test/test_callback.py
+++ b/examples/test/test_callback.py
@@ -1,21 +1,26 @@
 """Tests for callback example."""
 
+import pytest
 from aws_durable_execution_sdk_python.execution import InvocationStatus
 
-from aws_durable_execution_sdk_python_testing.runner import (
-    DurableFunctionTestResult,
-    DurableFunctionTestRunner,
-)
 from src import callback
+from test.conftest import deserialize_operation_payload
 
 
-def test_callback():
+@pytest.mark.example
+@pytest.mark.durable_execution(
+    handler=callback.handler,
+    lambda_function_name="callback",
+)
+def test_callback(durable_runner):
     """Test callback example."""
-    with DurableFunctionTestRunner(handler=callback.handler) as runner:
-        result: DurableFunctionTestResult = runner.run(input="test", timeout=10)
+    with durable_runner:
+        result = durable_runner.run(input="test", timeout=10)
 
     assert result.status is InvocationStatus.SUCCEEDED
-    assert result.result.startswith("Callback created with ID:")
+    assert deserialize_operation_payload(result.result).startswith(
+        "Callback created with ID:"
+    )
 
     # Find the callback operation
     callback_ops = [

--- a/examples/test/test_callback_permutations.py
+++ b/examples/test/test_callback_permutations.py
@@ -1,21 +1,26 @@
 """Tests for callback operation permutations."""
 
+import pytest
 from aws_durable_execution_sdk_python.execution import InvocationStatus
 
-from aws_durable_execution_sdk_python_testing.runner import (
-    DurableFunctionTestResult,
-    DurableFunctionTestRunner,
-)
 from src import callback_with_timeout
+from test.conftest import deserialize_operation_payload
 
 
-def test_callback_with_timeout():
+@pytest.mark.example
+@pytest.mark.durable_execution(
+    handler=callback_with_timeout.handler,
+    lambda_function_name="callback with timeout",
+)
+def test_callback_with_timeout(durable_runner):
     """Test callback with custom timeout configuration."""
-    with DurableFunctionTestRunner(handler=callback_with_timeout.handler) as runner:
-        result: DurableFunctionTestResult = runner.run(input="test", timeout=10)
+    with durable_runner:
+        result = durable_runner.run(input="test", timeout=10)
 
     assert result.status is InvocationStatus.SUCCEEDED
-    assert result.result.startswith("Callback created with 60s timeout:")
+    assert deserialize_operation_payload(result.result).startswith(
+        "Callback created with 60s timeout:"
+    )
 
     callback_ops = [
         op for op in result.operations if op.operation_type.value == "CALLBACK"

--- a/examples/test/test_hello_world.py
+++ b/examples/test/test_hello_world.py
@@ -1,18 +1,21 @@
-"""Integration tests for example durable functions."""
+"""Integration tests for hello world example."""
 
+import pytest
 from aws_durable_execution_sdk_python.execution import InvocationStatus
 
-from aws_durable_execution_sdk_python_testing.runner import (
-    DurableFunctionTestResult,
-    DurableFunctionTestRunner,
-)
 from src import hello_world
+from test.conftest import deserialize_operation_payload
 
 
-def test_hello_world():
+@pytest.mark.example
+@pytest.mark.durable_execution(
+    handler=hello_world.handler,
+    lambda_function_name="hello world",
+)
+def test_hello_world(durable_runner):
     """Test hello world example."""
-    with DurableFunctionTestRunner(handler=hello_world.handler) as runner:
-        result: DurableFunctionTestResult = runner.run(input="test", timeout=10)
+    with durable_runner:
+        result = durable_runner.run(input="test", timeout=10)
 
     assert result.status is InvocationStatus.SUCCEEDED
-    assert result.result == "Hello World!"
+    assert deserialize_operation_payload(result.result) == "Hello World!"

--- a/examples/test/test_logger_example.py
+++ b/examples/test/test_logger_example.py
@@ -1,0 +1,35 @@
+"""Tests for logger_example."""
+
+import pytest
+from aws_durable_execution_sdk_python.execution import InvocationStatus
+from aws_durable_execution_sdk_python.lambda_service import OperationType
+
+from src import logger_example
+from test.conftest import deserialize_operation_payload
+
+
+@pytest.mark.example
+@pytest.mark.durable_execution(
+    handler=logger_example.handler,
+    lambda_function_name="logger example",
+)
+def test_logger_example(durable_runner):
+    """Test logger example."""
+    with durable_runner:
+        result = durable_runner.run(input={"id": "test-123"}, timeout=10)
+
+    assert result.status is InvocationStatus.SUCCEEDED
+    assert deserialize_operation_payload(result.result) == "processed-child-processed"
+
+    # Verify step operations exist (process_data at top level)
+    # Note: child_step is nested inside the CONTEXT operation, not at top level
+    step_ops = [
+        op for op in result.operations if op.operation_type == OperationType.STEP
+    ]
+    assert len(step_ops) >= 1
+
+    # Verify context operation exists (child_workflow)
+    context_ops = [
+        op for op in result.operations if op.operation_type.value == "CONTEXT"
+    ]
+    assert len(context_ops) >= 1

--- a/examples/test/test_run_in_child_context.py
+++ b/examples/test/test_run_in_child_context.py
@@ -1,21 +1,24 @@
 """Tests for run_in_child_context example."""
 
+import pytest
 from aws_durable_execution_sdk_python.execution import InvocationStatus
 
-from aws_durable_execution_sdk_python_testing.runner import (
-    DurableFunctionTestResult,
-    DurableFunctionTestRunner,
-)
 from src import run_in_child_context
+from test.conftest import deserialize_operation_payload
 
 
-def test_run_in_child_context():
+@pytest.mark.example
+@pytest.mark.durable_execution(
+    handler=run_in_child_context.handler,
+    lambda_function_name="run in child context",
+)
+def test_run_in_child_context(durable_runner):
     """Test run_in_child_context example."""
-    with DurableFunctionTestRunner(handler=run_in_child_context.handler) as runner:
-        result: DurableFunctionTestResult = runner.run(input="test", timeout=10)
+    with durable_runner:
+        result = durable_runner.run(input="test", timeout=10)
 
     assert result.status is InvocationStatus.SUCCEEDED
-    assert result.result == "Child context result: 10"
+    assert deserialize_operation_payload(result.result) == "Child context result: 10"
 
     # Verify child context operation exists
     context_ops = [

--- a/examples/test/test_step.py
+++ b/examples/test/test_step.py
@@ -1,22 +1,24 @@
 """Tests for step example."""
 
+import pytest
 from aws_durable_execution_sdk_python.execution import InvocationStatus
 
-from aws_durable_execution_sdk_python_testing.runner import (
-    DurableFunctionTestResult,
-    DurableFunctionTestRunner,
-    StepOperation,
-)
 from src import step
+from test.conftest import deserialize_operation_payload
 
 
-def test_step():
+@pytest.mark.example
+@pytest.mark.durable_execution(
+    handler=step.handler,
+    lambda_function_name="Basic Step",
+)
+def test_step(durable_runner):
     """Test basic step example."""
-    with DurableFunctionTestRunner(handler=step.handler) as runner:
-        result: DurableFunctionTestResult = runner.run(input="test", timeout=10)
+    with durable_runner:
+        result = durable_runner.run(input="test", timeout=10)
 
     assert result.status is InvocationStatus.SUCCEEDED
-    assert result.result == 8
+    assert deserialize_operation_payload(result.result) == 8
 
-    step_result: StepOperation = result.get_step("add_numbers")
-    assert step_result.result == 8
+    step_result = result.get_step("add_numbers")
+    assert deserialize_operation_payload(step_result.result) == 8

--- a/examples/test/test_step_permutations.py
+++ b/examples/test/test_step_permutations.py
@@ -1,51 +1,75 @@
 """Tests for step operation permutations."""
 
+import pytest
 from aws_durable_execution_sdk_python.execution import InvocationStatus
+from aws_durable_execution_sdk_python.lambda_service import OperationType
 
-from aws_durable_execution_sdk_python_testing.runner import (
-    DurableFunctionTestResult,
-    DurableFunctionTestRunner,
-)
 from src import step_no_name, step_with_exponential_backoff, step_with_name
+from test.conftest import deserialize_operation_payload
 
 
-def test_step_no_name():
+@pytest.mark.example
+@pytest.mark.durable_execution(
+    handler=step_no_name.handler,
+    lambda_function_name="step no name",
+)
+def test_step_no_name(durable_runner):
     """Test step without explicit name."""
-    with DurableFunctionTestRunner(handler=step_no_name.handler) as runner:
-        result: DurableFunctionTestResult = runner.run(input="test", timeout=10)
+    with durable_runner:
+        result = durable_runner.run(input="test", timeout=10)
 
     assert result.status is InvocationStatus.SUCCEEDED
-    assert result.result == "Result: Step without name"
+    assert deserialize_operation_payload(result.result) == "Result: Step without name"
 
-    step_ops = [op for op in result.operations if op.operation_type.value == "STEP"]
+    step_ops = [
+        op for op in result.operations if op.operation_type == OperationType.STEP
+    ]
     assert len(step_ops) == 1
     # Should use function name when no name provided
     assert step_ops[0].name is None or step_ops[0].name == "<lambda>"
 
 
-def test_step_with_name():
+@pytest.mark.example
+@pytest.mark.durable_execution(
+    handler=step_with_name.handler,
+    lambda_function_name="step with name",
+)
+def test_step_with_name(durable_runner):
     """Test step with explicit name."""
-    with DurableFunctionTestRunner(handler=step_with_name.handler) as runner:
-        result: DurableFunctionTestResult = runner.run(input="test", timeout=10)
+    with durable_runner:
+        result = durable_runner.run(input="test", timeout=10)
 
     assert result.status is InvocationStatus.SUCCEEDED
-    assert result.result == "Result: Step with explicit name"
+    assert (
+        deserialize_operation_payload(result.result)
+        == "Result: Step with explicit name"
+    )
 
-    step_ops = [op for op in result.operations if op.operation_type.value == "STEP"]
+    step_ops = [
+        op for op in result.operations if op.operation_type == OperationType.STEP
+    ]
     assert len(step_ops) == 1
     assert step_ops[0].name == "custom_step"
 
 
-def test_step_with_exponential_backoff():
+@pytest.mark.example
+@pytest.mark.durable_execution(
+    handler=step_with_exponential_backoff.handler,
+    lambda_function_name="step with exponential backoff",
+)
+def test_step_with_exponential_backoff(durable_runner):
     """Test step with exponential backoff retry strategy."""
-    with DurableFunctionTestRunner(
-        handler=step_with_exponential_backoff.handler
-    ) as runner:
-        result: DurableFunctionTestResult = runner.run(input="test", timeout=10)
+    with durable_runner:
+        result = durable_runner.run(input="test", timeout=10)
 
     assert result.status is InvocationStatus.SUCCEEDED
-    assert result.result == "Result: Step with exponential backoff"
+    assert (
+        deserialize_operation_payload(result.result)
+        == "Result: Step with exponential backoff"
+    )
 
-    step_ops = [op for op in result.operations if op.operation_type.value == "STEP"]
+    step_ops = [
+        op for op in result.operations if op.operation_type == OperationType.STEP
+    ]
     assert len(step_ops) == 1
     assert step_ops[0].name == "retry_step"

--- a/examples/test/test_step_semantics_at_most_once.py
+++ b/examples/test/test_step_semantics_at_most_once.py
@@ -1,0 +1,32 @@
+"""Tests for step_semantics_at_most_once example."""
+
+import pytest
+from aws_durable_execution_sdk_python.execution import InvocationStatus
+from aws_durable_execution_sdk_python.lambda_service import OperationType
+
+from src import step_semantics_at_most_once
+from test.conftest import deserialize_operation_payload
+
+
+@pytest.mark.example
+@pytest.mark.durable_execution(
+    handler=step_semantics_at_most_once.handler,
+    lambda_function_name="step semantics at most once",
+)
+def test_step_semantics_at_most_once(durable_runner):
+    """Test step with at-most-once semantics."""
+    with durable_runner:
+        result = durable_runner.run(input="test", timeout=10)
+
+    assert result.status is InvocationStatus.SUCCEEDED
+    assert (
+        deserialize_operation_payload(result.result)
+        == "Result: AT_MOST_ONCE_PER_RETRY semantics"
+    )
+
+    # Verify step operation exists with correct name
+    step_ops = [
+        op for op in result.operations if op.operation_type == OperationType.STEP
+    ]
+    assert len(step_ops) == 1
+    assert step_ops[0].name == "at_most_once_step"

--- a/examples/test/test_step_with_retry.py
+++ b/examples/test/test_step_with_retry.py
@@ -1,0 +1,33 @@
+"""Tests for step_with_retry example."""
+
+import pytest
+from aws_durable_execution_sdk_python.execution import InvocationStatus
+from aws_durable_execution_sdk_python.lambda_service import OperationType
+
+from src import step_with_retry
+from test.conftest import deserialize_operation_payload
+
+
+@pytest.mark.example
+@pytest.mark.durable_execution(
+    handler=step_with_retry.handler,
+    lambda_function_name="step with retry",
+)
+def test_step_with_retry(durable_runner):
+    """Test step with retry configuration."""
+    with durable_runner:
+        result = durable_runner.run(input="test", timeout=30)
+
+    # The function uses random() so it may succeed or fail
+    # We just verify it completes and has retry configuration
+    assert result.status in [InvocationStatus.SUCCEEDED, InvocationStatus.FAILED]
+
+    # Verify step operation exists
+    step_ops = [
+        op for op in result.operations if op.operation_type == OperationType.STEP
+    ]
+    assert len(step_ops) >= 1
+
+    # If it succeeded, verify the result
+    if result.status is InvocationStatus.SUCCEEDED:
+        assert deserialize_operation_payload(result.result) == "Operation succeeded"

--- a/examples/test/test_steps_with_retry.py
+++ b/examples/test/test_steps_with_retry.py
@@ -1,0 +1,33 @@
+"""Tests for steps_with_retry."""
+
+import pytest
+from aws_durable_execution_sdk_python.execution import InvocationStatus
+from aws_durable_execution_sdk_python.lambda_service import OperationType
+
+from src import steps_with_retry
+from test.conftest import deserialize_operation_payload
+
+
+@pytest.mark.example
+@pytest.mark.durable_execution(
+    handler=steps_with_retry.handler,
+    lambda_function_name="steps with retry",
+)
+def test_steps_with_retry(durable_runner):
+    """Test steps_with_retry pattern."""
+    with durable_runner:
+        result = durable_runner.run(input={"name": "test-item"}, timeout=30)
+
+    assert result.status is InvocationStatus.SUCCEEDED
+
+    # Result should be either success with item or error
+    assert isinstance(deserialize_operation_payload(result.result), dict)
+    assert "success" in deserialize_operation_payload(
+        result.result
+    ) or "error" in deserialize_operation_payload(result.result)
+
+    # Verify step operations exist (polling steps)
+    step_ops = [
+        op for op in result.operations if op.operation_type == OperationType.STEP
+    ]
+    assert len(step_ops) >= 1

--- a/examples/test/test_wait.py
+++ b/examples/test/test_wait.py
@@ -1,21 +1,24 @@
 """Tests for wait example."""
 
+import pytest
 from aws_durable_execution_sdk_python.execution import InvocationStatus
 
-from aws_durable_execution_sdk_python_testing.runner import (
-    DurableFunctionTestResult,
-    DurableFunctionTestRunner,
-)
 from src import wait
+from test.conftest import deserialize_operation_payload
 
 
-def test_wait():
+@pytest.mark.example
+@pytest.mark.durable_execution(
+    handler=wait.handler,
+    lambda_function_name="Wait State",
+)
+def test_wait(durable_runner):
     """Test wait example."""
-    with DurableFunctionTestRunner(handler=wait.handler) as runner:
-        result: DurableFunctionTestResult = runner.run(input="test", timeout=10)
+    with durable_runner:
+        result = durable_runner.run(input="test", timeout=10)
 
     assert result.status is InvocationStatus.SUCCEEDED
-    assert result.result == "Wait completed"
+    assert deserialize_operation_payload(result.result) == "Wait completed"
 
     # Find the wait operation (it should be the only non-execution operation)
     wait_ops = [op for op in result.operations if op.operation_type.value == "WAIT"]

--- a/examples/test/test_wait_for_condition.py
+++ b/examples/test/test_wait_for_condition.py
@@ -1,0 +1,33 @@
+"""Tests for wait_for_condition."""
+
+import pytest
+from aws_durable_execution_sdk_python.execution import InvocationStatus
+from aws_durable_execution_sdk_python.lambda_service import OperationType
+
+from src import wait_for_condition
+from test.conftest import deserialize_operation_payload
+
+
+@pytest.mark.example
+@pytest.mark.durable_execution(
+    handler=wait_for_condition.handler,
+    lambda_function_name="wait for condition",
+)
+def test_wait_for_condition(durable_runner):
+    """Test wait_for_condition pattern."""
+    with durable_runner:
+        result = durable_runner.run(input="test", timeout=15)
+
+    assert result.status is InvocationStatus.SUCCEEDED
+    # Should reach state 3 after 3 increments
+    assert deserialize_operation_payload(result.result) == 3
+
+    # Verify step operations exist (should have 3 increment steps)
+    step_ops = [
+        op for op in result.operations if op.operation_type == OperationType.STEP
+    ]
+    assert len(step_ops) == 3
+
+    # Verify wait operations exist (should have 2 waits before final state)
+    wait_ops = [op for op in result.operations if op.operation_type.value == "WAIT"]
+    assert len(wait_ops) == 2

--- a/examples/test/test_wait_permutations.py
+++ b/examples/test/test_wait_permutations.py
@@ -1,21 +1,24 @@
 """Tests for wait operation permutations."""
 
+import pytest
 from aws_durable_execution_sdk_python.execution import InvocationStatus
 
-from aws_durable_execution_sdk_python_testing.runner import (
-    DurableFunctionTestResult,
-    DurableFunctionTestRunner,
-)
 from src import wait_with_name
+from test.conftest import deserialize_operation_payload
 
 
-def test_wait_with_name():
+@pytest.mark.example
+@pytest.mark.durable_execution(
+    handler=wait_with_name.handler,
+    lambda_function_name="wait with name",
+)
+def test_wait_with_name(durable_runner):
     """Test wait with explicit name."""
-    with DurableFunctionTestRunner(handler=wait_with_name.handler) as runner:
-        result: DurableFunctionTestResult = runner.run(input="test", timeout=10)
+    with durable_runner:
+        result = durable_runner.run(input="test", timeout=10)
 
     assert result.status is InvocationStatus.SUCCEEDED
-    assert result.result == "Wait with name completed"
+    assert deserialize_operation_payload(result.result) == "Wait with name completed"
 
     wait_ops = [op for op in result.operations if op.operation_type.value == "WAIT"]
     assert len(wait_ops) == 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,8 @@ dependencies = [
 
 [tool.hatch.envs.test.scripts]
 test = "pytest tests/ -v"
-examples = "pytest examples/test/ -v"
+examples = "pytest --runner-mode=local -m example examples/test/ -v"
+examples-integration = "pytest --runner-mode=cloud -m example examples/test/ -v {args}"
 cov = "pytest --cov-report=term-missing --cov-config=pyproject.toml --cov=src/aws_durable_execution_sdk_python_testing --cov-fail-under=96"
 
 [tool.hatch.envs.examples]
@@ -115,6 +116,7 @@ target-version = "py313"
 
 [tool.ruff.lint]
 preview = false
+select = ["TID252"]  # Enforce absolute imports (ban relative imports)
 
 [tool.ruff.lint.isort]
 known-first-party = ["aws_durable_execution_sdk_python_testing"]
@@ -143,3 +145,16 @@ lines-after-imports = 2
 "src/aws_durable_execution_sdk_python_testing/invoker.py" = [
   "A002", # Argument `input` is shadowing a Python builtin
 ]
+
+[tool.pytest.ini_options]
+# Declare custom markers to avoid warnings with --strict-markers
+markers = [
+  # Used for test selection with -m example
+  "example: marks tests as example tests (deselect with '-m \"not example\"')",
+  # Used for configuration - passes handler and lambda_function_name to durable_runner fixture
+  "durable_execution: marks tests that use the durable_runner fixture (not used for test selection)",
+]
+# Default test discovery paths
+testpaths = ["tests", "examples/test"]
+# Default options for all test runs
+addopts = "-v --strict-markers"

--- a/src/aws_durable_execution_sdk_python_testing/__init__.py
+++ b/src/aws_durable_execution_sdk_python_testing/__init__.py
@@ -1,3 +1,20 @@
 """DurableExecutionsPythonTestingLibrary module."""
 
-# Implement your code here.
+from aws_durable_execution_sdk_python_testing.runner import (
+    DurableChildContextTestRunner,
+    DurableFunctionCloudTestRunner,
+    DurableFunctionTestResult,
+    DurableFunctionTestRunner,
+    WebRunner,
+    WebRunnerConfig,
+)
+
+
+__all__ = [
+    "DurableChildContextTestRunner",
+    "DurableFunctionCloudTestRunner",
+    "DurableFunctionTestResult",
+    "DurableFunctionTestRunner",
+    "WebRunner",
+    "WebRunnerConfig",
+]

--- a/src/aws_durable_execution_sdk_python_testing/executor.py
+++ b/src/aws_durable_execution_sdk_python_testing/executor.py
@@ -142,15 +142,15 @@ class Executor(ExecutionObserver):
             durable_execution_name=execution.start_input.execution_name,
             function_arn=f"arn:aws:lambda:us-east-1:123456789012:function:{execution.start_input.function_name}",
             status=status,
-            start_timestamp=execution_op.start_timestamp.timestamp()
+            start_timestamp=execution_op.start_timestamp
             if execution_op.start_timestamp
-            else datetime.now(UTC).timestamp(),
+            else datetime.now(UTC),
             input_payload=execution_op.execution_details.input_payload
             if execution_op.execution_details
             else None,
             result=result,
             error=error,
-            end_timestamp=execution_op.end_timestamp.timestamp()
+            end_timestamp=execution_op.end_timestamp
             if execution_op.end_timestamp
             else None,
             version="1.0",
@@ -223,10 +223,10 @@ class Executor(ExecutionObserver):
                 durable_execution_name=execution.start_input.execution_name,
                 function_arn=f"arn:aws:lambda:us-east-1:123456789012:function:{execution.start_input.function_name}",
                 status=execution_status,
-                start_timestamp=execution_op.start_timestamp.timestamp()
+                start_timestamp=execution_op.start_timestamp
                 if execution_op.start_timestamp
-                else datetime.now(UTC).timestamp(),
-                end_timestamp=execution_op.end_timestamp.timestamp()
+                else datetime.now(UTC),
+                end_timestamp=execution_op.end_timestamp
                 if execution_op.end_timestamp
                 else None,
             )
@@ -333,7 +333,7 @@ class Executor(ExecutionObserver):
         # Stop the execution
         self.fail_execution(execution_arn, stop_error)
 
-        return StopDurableExecutionResponse(end_timestamp=datetime.now(UTC).timestamp())
+        return StopDurableExecutionResponse(stop_timestamp=datetime.now(UTC))
 
     def get_execution_state(
         self,

--- a/tests/e2e/basic_success_path_test.py
+++ b/tests/e2e/basic_success_path_test.py
@@ -1,5 +1,6 @@
 """Functional tests, covering end-to-end DurableTestRunner."""
 
+import json
 from typing import Any
 
 from aws_durable_execution_sdk_python.context import (
@@ -71,16 +72,16 @@ def test_basic_durable_function() -> None:
         result: DurableFunctionTestResult = runner.run(input="input str", timeout=10)
 
     assert result.status is InvocationStatus.SUCCEEDED
-    assert result.result == ["1 2", "3 4 4 3", "5 6"]
+    assert result.result == json.dumps(["1 2", "3 4 4 3", "5 6"])
 
     one_result: StepOperation = result.get_step("one")
-    assert one_result.result == "1 2"
+    assert one_result.result == json.dumps("1 2")
 
     two_result: ContextOperation = result.get_context("two")
-    assert two_result.result == "3 4 4 3"
+    assert two_result.result == json.dumps("3 4 4 3")
 
     three_result: StepOperation = result.get_step("three")
-    assert three_result.result == "5 6"
+    assert three_result.result == json.dumps("5 6")
 
     # currently has the optimization where it's not saving child checkpoints after parent done
     # prob should unpick that for test

--- a/tests/executor_test.py
+++ b/tests/executor_test.py
@@ -1860,7 +1860,7 @@ def test_stop_execution(executor, mock_store):
 
     mock_store.load.assert_called_once_with("test-arn")
     mock_fail.assert_called_once()
-    assert result.end_timestamp is not None
+    assert result.stop_timestamp is not None
 
 
 def test_stop_execution_already_complete(executor, mock_store):

--- a/tests/web/handlers_test.py
+++ b/tests/web/handlers_test.py
@@ -870,7 +870,7 @@ def test_stop_durable_execution_handler_success():
     handler = StopDurableExecutionHandler(executor)
 
     # Mock the executor response
-    mock_response = StopDurableExecutionResponse(end_timestamp="2023-01-01T00:01:00Z")
+    mock_response = StopDurableExecutionResponse(stop_timestamp="2023-01-01T00:01:00Z")
     executor.stop_execution.return_value = mock_response
 
     # Create request with proper stop data
@@ -900,7 +900,7 @@ def test_stop_durable_execution_handler_success():
 
     # Verify response
     assert response.status_code == 200
-    assert response.body == {"EndTimestamp": "2023-01-01T00:01:00Z"}
+    assert response.body == {"StopTimestamp": "2023-01-01T00:01:00Z"}
 
     # Verify executor was called with correct parameters
     executor.stop_execution.assert_called_once()


### PR DESCRIPTION
Add comprehensive integration testing infrastructure that supports both local (in-memory) and cloud (AWS Lambda) test execution modes with a unified test interface.

*Issue #, if available:*

*Description of changes:*

Key Features:
- CloudDurableFunctionTestRunner for AWS Lambda integration tests
- Dual-mode test helper pattern for seamless local/cloud testing
- CI/CD integration with automated cloud testing

New Infrastructure:
- cloud_runner.py: AWS Lambda test runner with polling support
- test_helper.py: Dual-mode test pattern implementation

Configuration Updates:
- examples-catalog.json: Added 4 new examples
- template.yaml: Added Lambda resources for new examples
- pyproject.toml: Added integration test commands
- deploy-examples.yml: Added integration test step