### PR TITLE
chore: rename @durable_handler to @durable_execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ from durable_executions_python_language_sdk.context import (
     durable_step,
     durable_with_child_context,
 )
-from durable_executions_python_language_sdk.execution import durable_handler
+from durable_executions_python_language_sdk.execution import durable_execution
 
 @durable_step
 def one(a: int, b: int) -> str:
@@ -61,7 +61,7 @@ def two(ctx: DurableContext, a: int, b: int) -> str:
 def three(a: int, b: int) -> str:
     return f"{a} {b}"
 
-@durable_handler
+@durable_execution
 def function_under_test(event: Any, context: DurableContext) -> list[str]:
     results: list[str] = []
 

--- a/examples/src/callback.py
+++ b/examples/src/callback.py
@@ -2,14 +2,14 @@ from typing import TYPE_CHECKING, Any
 
 from aws_durable_execution_sdk_python.config import CallbackConfig
 from aws_durable_execution_sdk_python.context import DurableContext
-from aws_durable_execution_sdk_python.execution import durable_handler
+from aws_durable_execution_sdk_python.execution import durable_execution
 
 
 if TYPE_CHECKING:
     from aws_durable_execution_sdk_python.types import Callback
 
 
-@durable_handler
+@durable_execution
 def handler(_event: Any, context: DurableContext) -> str:
     callback_config = CallbackConfig(timeout_seconds=120, heartbeat_timeout_seconds=60)
 

--- a/examples/src/callback_with_timeout.py
+++ b/examples/src/callback_with_timeout.py
@@ -2,14 +2,14 @@ from typing import TYPE_CHECKING, Any
 
 from aws_durable_execution_sdk_python.config import CallbackConfig
 from aws_durable_execution_sdk_python.context import DurableContext
-from aws_durable_execution_sdk_python.execution import durable_handler
+from aws_durable_execution_sdk_python.execution import durable_execution
 
 
 if TYPE_CHECKING:
     from aws_durable_execution_sdk_python.types import Callback
 
 
-@durable_handler
+@durable_execution
 def handler(_event: Any, context: DurableContext) -> str:
     # Callback with custom timeout configuration
     config = CallbackConfig(timeout_seconds=60, heartbeat_timeout_seconds=30)

--- a/examples/src/hello_world.py
+++ b/examples/src/hello_world.py
@@ -1,10 +1,10 @@
 from typing import Any
 
 from aws_durable_execution_sdk_python.context import DurableContext
-from aws_durable_execution_sdk_python.execution import durable_handler
+from aws_durable_execution_sdk_python.execution import durable_execution
 
 
-@durable_handler
+@durable_execution
 def handler(_event: Any, _context: DurableContext) -> str:
     """Simple hello world durable function."""
     return "Hello World!"

--- a/examples/src/map_operations.py
+++ b/examples/src/map_operations.py
@@ -1,14 +1,14 @@
 from typing import Any
 
 from aws_durable_execution_sdk_python.context import DurableContext
-from aws_durable_execution_sdk_python.execution import durable_handler
+from aws_durable_execution_sdk_python.execution import durable_execution
 
 
 def square(x: int) -> int:
     return x * x
 
 
-@durable_handler
+@durable_execution
 def handler(_event: Any, context: DurableContext) -> str:
     # Process a list of items using map-like operations
     items = [1, 2, 3, 4, 5]

--- a/examples/src/parallel.py
+++ b/examples/src/parallel.py
@@ -1,10 +1,10 @@
 from typing import Any
 
 from aws_durable_execution_sdk_python.context import DurableContext
-from aws_durable_execution_sdk_python.execution import durable_handler
+from aws_durable_execution_sdk_python.execution import durable_execution
 
 
-@durable_handler
+@durable_execution
 def handler(_event: Any, context: DurableContext) -> str:
     # Execute multiple operations in parallel
     task1 = context.step(lambda _: "Task 1 complete", name="task1")

--- a/examples/src/parallel_first_successful.py
+++ b/examples/src/parallel_first_successful.py
@@ -2,10 +2,10 @@ from typing import Any
 
 from aws_durable_execution_sdk_python.config import CompletionConfig, ParallelConfig
 from aws_durable_execution_sdk_python.context import DurableContext
-from aws_durable_execution_sdk_python.execution import durable_handler
+from aws_durable_execution_sdk_python.execution import durable_execution
 
 
-@durable_handler
+@durable_execution
 def handler(_event: Any, context: DurableContext) -> str:
     # Parallel execution with first_successful completion strategy
     config = ParallelConfig(completion_config=CompletionConfig.first_successful())

--- a/examples/src/run_in_child_context.py
+++ b/examples/src/run_in_child_context.py
@@ -4,7 +4,7 @@ from aws_durable_execution_sdk_python.context import (
     DurableContext,
     durable_with_child_context,
 )
-from aws_durable_execution_sdk_python.execution import durable_handler
+from aws_durable_execution_sdk_python.execution import durable_execution
 
 
 def multiply_by_two(value: int) -> int:
@@ -16,7 +16,7 @@ def child_operation(ctx: DurableContext, value: int) -> int:
     return ctx.step(lambda _: multiply_by_two(value), name="multiply")
 
 
-@durable_handler
+@durable_execution
 def handler(_event: Any, context: DurableContext) -> str:
     result = context.run_in_child_context(child_operation(5))
     return f"Child context result: {result}"

--- a/examples/src/step.py
+++ b/examples/src/step.py
@@ -5,7 +5,7 @@ from aws_durable_execution_sdk_python.context import (
     StepContext,
     durable_step,
 )
-from aws_durable_execution_sdk_python.execution import durable_handler
+from aws_durable_execution_sdk_python.execution import durable_execution
 
 
 @durable_step
@@ -13,7 +13,7 @@ def add_numbers(_step_context: StepContext, a: int, b: int) -> int:
     return a + b
 
 
-@durable_handler
+@durable_execution
 def handler(_event: Any, context: DurableContext) -> int:
     result: int = context.step(add_numbers(5, 3))
     return result

--- a/examples/src/step_no_name.py
+++ b/examples/src/step_no_name.py
@@ -1,10 +1,10 @@
 from typing import Any
 
 from aws_durable_execution_sdk_python.context import DurableContext
-from aws_durable_execution_sdk_python.execution import durable_handler
+from aws_durable_execution_sdk_python.execution import durable_execution
 
 
-@durable_handler
+@durable_execution
 def handler(_event: Any, context: DurableContext) -> str:
     # Step without explicit name - should use function name
     result = context.step(lambda _: "Step without name")

--- a/examples/src/step_semantics_at_most_once.py
+++ b/examples/src/step_semantics_at_most_once.py
@@ -2,10 +2,10 @@ from typing import Any
 
 from aws_durable_execution_sdk_python.config import StepConfig, StepSemantics
 from aws_durable_execution_sdk_python.context import DurableContext
-from aws_durable_execution_sdk_python.execution import durable_handler
+from aws_durable_execution_sdk_python.execution import durable_execution
 
 
-@durable_handler
+@durable_execution
 def handler(_event: Any, context: DurableContext) -> str:
     # Step with AT_MOST_ONCE_PER_RETRY semantics
     config = StepConfig(step_semantics=StepSemantics.AT_MOST_ONCE_PER_RETRY)

--- a/examples/src/step_with_exponential_backoff.py
+++ b/examples/src/step_with_exponential_backoff.py
@@ -2,14 +2,14 @@ from typing import Any
 
 from aws_durable_execution_sdk_python.config import StepConfig
 from aws_durable_execution_sdk_python.context import DurableContext
-from aws_durable_execution_sdk_python.execution import durable_handler
+from aws_durable_execution_sdk_python.execution import durable_execution
 from aws_durable_execution_sdk_python.retries import (
     RetryStrategyConfig,
     create_retry_strategy,
 )
 
 
-@durable_handler
+@durable_execution
 def handler(_event: Any, context: DurableContext) -> str:
     # Step with exponential backoff retry strategy
     retry_config = RetryStrategyConfig(

--- a/examples/src/step_with_name.py
+++ b/examples/src/step_with_name.py
@@ -1,10 +1,10 @@
 from typing import Any
 
 from aws_durable_execution_sdk_python.context import DurableContext
-from aws_durable_execution_sdk_python.execution import durable_handler
+from aws_durable_execution_sdk_python.execution import durable_execution
 
 
-@durable_handler
+@durable_execution
 def handler(_event: Any, context: DurableContext) -> str:
     # Step with explicit name
     result = context.step(lambda _: "Step with explicit name", name="custom_step")

--- a/examples/src/step_with_retry.py
+++ b/examples/src/step_with_retry.py
@@ -6,7 +6,7 @@ from aws_durable_execution_sdk_python.context import (
     DurableContext,
     durable_step,
 )
-from aws_durable_execution_sdk_python.execution import durable_handler
+from aws_durable_execution_sdk_python.execution import durable_execution
 from aws_durable_execution_sdk_python.retries import (
     RetryStrategyConfig,
     create_retry_strategy,
@@ -22,7 +22,7 @@ def unreliable_operation() -> str:
     return "Operation succeeded"
 
 
-@durable_handler
+@durable_execution
 def handler(_event: Any, context: DurableContext) -> str:
     retry_config = RetryStrategyConfig(
         max_attempts=3,

--- a/examples/src/wait.py
+++ b/examples/src/wait.py
@@ -1,10 +1,10 @@
 from typing import Any
 
 from aws_durable_execution_sdk_python.context import DurableContext
-from aws_durable_execution_sdk_python.execution import durable_handler
+from aws_durable_execution_sdk_python.execution import durable_execution
 
 
-@durable_handler
+@durable_execution
 def handler(_event: Any, context: DurableContext) -> str:
     context.wait(seconds=5)
     return "Wait completed"

--- a/examples/src/wait_for_callback.py
+++ b/examples/src/wait_for_callback.py
@@ -2,7 +2,7 @@ from typing import Any
 
 from aws_durable_execution_sdk_python.config import WaitForCallbackConfig
 from aws_durable_execution_sdk_python.context import DurableContext
-from aws_durable_execution_sdk_python.execution import durable_handler
+from aws_durable_execution_sdk_python.execution import durable_execution
 
 
 def external_system_call(_callback_id: str) -> None:
@@ -11,7 +11,7 @@ def external_system_call(_callback_id: str) -> None:
     # passing the callback_id for the system to call back when done
 
 
-@durable_handler
+@durable_execution
 def handler(_event: Any, context: DurableContext) -> str:
     config = WaitForCallbackConfig(timeout_seconds=120, heartbeat_timeout_seconds=60)
 

--- a/examples/src/wait_with_name.py
+++ b/examples/src/wait_with_name.py
@@ -1,10 +1,10 @@
 from typing import Any
 
 from aws_durable_execution_sdk_python.context import DurableContext
-from aws_durable_execution_sdk_python.execution import durable_handler
+from aws_durable_execution_sdk_python.execution import durable_execution
 
 
-@durable_handler
+@durable_execution
 def handler(_event: Any, context: DurableContext) -> str:
     # Wait with explicit name
     context.wait(seconds=2, name="custom_wait")

--- a/src/aws_durable_execution_sdk_python_testing/runner.py
+++ b/src/aws_durable_execution_sdk_python_testing/runner.py
@@ -19,7 +19,7 @@ import aws_durable_execution_sdk_python
 import boto3  # type: ignore
 from aws_durable_execution_sdk_python.execution import (
     InvocationStatus,
-    durable_handler,
+    durable_execution,
 )
 from aws_durable_execution_sdk_python.lambda_service import (
     ErrorObject,
@@ -533,8 +533,8 @@ class DurableChildContextTestRunner(DurableFunctionTestRunner):
         *args,
         **kwargs,
     ):
-        # wrap the durable context around a durable handler as a convenience to run directly
-        @durable_handler
+        # wrap the durable context around a durable execution handler as a convenience to run directly
+        @durable_execution
         def handler(event: Any, context: DurableContext):  # noqa: ARG001
             return context_function(*args, **kwargs)(context)
 

--- a/tests/e2e/basic_success_path_test.py
+++ b/tests/e2e/basic_success_path_test.py
@@ -7,7 +7,10 @@ from aws_durable_execution_sdk_python.context import (
     durable_step,
     durable_with_child_context,
 )
-from aws_durable_execution_sdk_python.execution import InvocationStatus, durable_handler
+from aws_durable_execution_sdk_python.execution import (
+    InvocationStatus,
+    durable_execution,
+)
 from aws_durable_execution_sdk_python.types import StepContext
 
 from aws_durable_execution_sdk_python_testing.runner import (
@@ -47,7 +50,7 @@ def test_basic_durable_function() -> None:
         # print("[DEBUG] three called")
         return f"{a} {b}"
 
-    @durable_handler
+    @durable_execution
     def function_under_test(event: Any, context: DurableContext) -> list[str]:
         results: list[str] = []
 

--- a/tests/runner_test.py
+++ b/tests/runner_test.py
@@ -933,9 +933,9 @@ def test_durable_function_test_result_create_with_parent_operations():
 @patch("aws_durable_execution_sdk_python_testing.runner.InMemoryServiceClient")
 @patch("aws_durable_execution_sdk_python_testing.runner.InProcessInvoker")
 @patch("aws_durable_execution_sdk_python_testing.runner.Executor")
-@patch("aws_durable_execution_sdk_python_testing.runner.durable_handler")
+@patch("aws_durable_execution_sdk_python_testing.runner.durable_execution")
 def test_durable_context_test_runner_init(
-    mock_durable_handler,
+    mock_durable_execution_handler,
     mock_executor,
     mock_invoker,
     mock_client,
@@ -946,7 +946,7 @@ def test_durable_context_test_runner_init(
     """Test DurableContextTestRunner initialization."""
     handler = Mock()
     decorated_handler = Mock()
-    mock_durable_handler.return_value = decorated_handler
+    mock_durable_execution_handler.return_value = decorated_handler
 
     DurableChildContextTestRunner(handler)  # type: ignore
 
@@ -964,15 +964,15 @@ def test_durable_context_test_runner_init(
         mock_executor.return_value
     )
 
-    # Verify durable_handler was called (with internal lambda function)
-    mock_durable_handler.assert_called_once()
+    # Verify durable_execution was called (with internal lambda function)
+    mock_durable_execution_handler.assert_called_once()
 
     # Verify the lambda function calls our handler
-    durable_handler_func = mock_durable_handler.call_args.args[0]
-    assert callable(durable_handler_func)
+    durable_execution_func = mock_durable_execution_handler.call_args.args[0]
+    assert callable(durable_execution_func)
 
     # verify handler is called when durable function is invoked
-    durable_handler_func(Mock(), Mock())
+    durable_execution_func(Mock(), Mock())
     handler.assert_called_once()
 
 
@@ -982,9 +982,9 @@ def test_durable_context_test_runner_init(
 @patch("aws_durable_execution_sdk_python_testing.runner.InMemoryServiceClient")
 @patch("aws_durable_execution_sdk_python_testing.runner.InProcessInvoker")
 @patch("aws_durable_execution_sdk_python_testing.runner.Executor")
-@patch("aws_durable_execution_sdk_python_testing.runner.durable_handler")
+@patch("aws_durable_execution_sdk_python_testing.runner.durable_execution")
 def test_durable_child_context_test_runner_init_with_args(
-    mock_durable_handler,
+    mock_durable_execution_handler,
     mock_executor,
     mock_invoker,
     mock_client,
@@ -995,7 +995,7 @@ def test_durable_child_context_test_runner_init_with_args(
     """Test DurableChildContextTestRunner initialization with additional args."""
     handler = Mock()
     decorated_handler = Mock()
-    mock_durable_handler.return_value = decorated_handler
+    mock_durable_execution_handler.return_value = decorated_handler
 
     str_input = "a random string input"
     num_input = 10
@@ -1015,12 +1015,12 @@ def test_durable_child_context_test_runner_init_with_args(
         mock_executor.return_value
     )
 
-    # Verify durable_handler was called (with internal lambda function)
-    mock_durable_handler.assert_called_once()
+    # Verify durable_execution was called (with internal lambda function)
+    mock_durable_execution_handler.assert_called_once()
     # Verify the lambda function calls our handler
-    durable_handler_func = mock_durable_handler.call_args.args[0]
-    assert callable(durable_handler_func)
+    durable_execution_func = mock_durable_execution_handler.call_args.args[0]
+    assert callable(durable_execution_func)
 
     # verify that handler is called with expected args when durable function is invoked
-    durable_handler_func(Mock(), Mock())
+    durable_execution_func(Mock(), Mock())
     handler.assert_called_once_with(str_input, num=num_input)


### PR DESCRIPTION
*Issue #, if available:*
[#99](https://github.com/aws/aws-durable-execution-sdk-python/issues/99)

*Description of changes:*
Renaming references of `@durable_handler` to `@durable_execution`.

## Dependencies
If this PR requires testing against a specific branch of the Python Language SDK (e.g., for unreleased changes), uncomment and specify the branch below. Otherwise, leave commented to use the main branch.

<!-- PYTHON_LANGUAGE_SDK_BRANCH: main -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
