### PR TITLE
fix(testing-sdk): checkpoint validation parent & duplicate IDs

### DIFF
--- a/src/aws_durable_execution_sdk_python_testing/web/serialization.py
+++ b/src/aws_durable_execution_sdk_python_testing/web/serialization.py
@@ -36,7 +36,7 @@ class Serializer(Protocol):
         Raises:
             InvalidParameterValueException: If serialization fails
         """
-        ...
+        ...  # pragma: no cover
 
 
 class Deserializer(Protocol):
@@ -54,7 +54,7 @@ class Deserializer(Protocol):
         Raises:
             InvalidParameterValueException: If deserialization fails
         """
-        ...
+        ...  # pragma: no cover
 
 
 class AwsRestJsonSerializer:


### PR DESCRIPTION
The SDK now uses background thread batching for checkpoints, which can send multiple updates for the same operation in a single batch (e.g., START followed by SUCCEED for fast-completing operations). Updated the checkpoint validator to allow this valid behavior.

Ref #52

Changes:
- Allow duplicate operation IDs in checkpoint batches for STEP/CONTEXT operations when first action is START and subsequent is non-START
- Reject duplicate IDs for other operation types (WAIT, CALLBACK, etc.)
- Add 11 new tests covering all duplicate/inconsistency scenarios
- Add pragma comments to Protocol method stubs in serialization.py

<!-- PYTHON_LANGUAGE_SDK_BRANCH: main -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
