### PR TITLE
fix(testing-sdk): fix datetime decoder for filesystem

### DIFF
--- a/src/aws_durable_execution_sdk_python_testing/stores/filesystem.py
+++ b/src/aws_durable_execution_sdk_python_testing/stores/filesystem.py
@@ -26,7 +26,9 @@ def datetime_object_hook(obj):
     """JSON object hook to convert unix timestamps back to datetime objects."""
     if isinstance(obj, dict):
         for key, value in obj.items():
-            if isinstance(value, int | float) and key.endswith(("_timestamp", "_time")):
+            if isinstance(value, int | float) and key.endswith(
+                ("_timestamp", "_time", "Timestamp", "Time")
+            ):
                 try:  # noqa: SIM105
                     obj[key] = datetime.fromtimestamp(value, tz=UTC)
                 except (ValueError, OSError):


### PR DESCRIPTION


*Issue #, if available:*

- use upper camel case as key in datetime object hook

## Dependencies
If this PR requires testing against a specific branch of the Python Language SDK (e.g., for unreleased changes), uncomment and specify the branch below. Otherwise, leave commented to use the main branch.

<!-- PYTHON_LANGUAGE_SDK_BRANCH: main -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
