### PR TITLE
fix(testing-sdk): remove duplicate store update, use invoke

### DIFF
--- a/src/aws_durable_execution_sdk_python_testing/executor.py
+++ b/src/aws_durable_execution_sdk_python_testing/executor.py
@@ -602,7 +602,6 @@ class Executor(ExecutionObserver):
                 self._complete_workflow(
                     execution_arn, result=None, error=response.error
                 )
-                self._store.save(execution)
 
             case InvocationStatus.SUCCEEDED:
                 if response.error is not None:
@@ -614,7 +613,6 @@ class Executor(ExecutionObserver):
                 self._complete_workflow(
                     execution_arn, result=response.result, error=None
                 )
-                self._store.save(execution)
 
             case InvocationStatus.PENDING:
                 if not execution.has_pending_operations(execution):

--- a/src/aws_durable_execution_sdk_python_testing/invoker.py
+++ b/src/aws_durable_execution_sdk_python_testing/invoker.py
@@ -143,9 +143,8 @@ class LambdaInvoker(Invoker):
         function_name: str,
         input: DurableExecutionInvocationInput,
     ) -> DurableExecutionInvocationOutput:
-        # TODO: temporary method name pre-build - switch to `invoke` for final
         # TODO: wrap ResourceNotFoundException from lambda in ResourceNotFoundException from this lib
-        response = self.lambda_client.invoke20150331(
+        response = self.lambda_client.invoke(
             FunctionName=function_name,
             InvocationType="RequestResponse",  # Synchronous invocation
             Payload=json.dumps(input.to_dict(), default=str),

--- a/tests/invoker_test.py
+++ b/tests/invoker_test.py
@@ -162,7 +162,7 @@ def test_lambda_invoker_invoke_success():
         {"Status": "SUCCEEDED", "Result": "lambda-result"}
     ).encode("utf-8")
 
-    lambda_client.invoke20150331.return_value = {
+    lambda_client.invoke.return_value = {
         "StatusCode": 200,
         "Payload": mock_payload,
     }
@@ -183,7 +183,7 @@ def test_lambda_invoker_invoke_success():
     assert result.result == "lambda-result"
 
     # Verify lambda client was called correctly
-    lambda_client.invoke20150331.assert_called_once_with(
+    lambda_client.invoke.assert_called_once_with(
         FunctionName="test-function",
         InvocationType="RequestResponse",
         Payload=json.dumps(input_data.to_dict(), default=str),
@@ -196,7 +196,7 @@ def test_lambda_invoker_invoke_failure():
 
     # Mock failed response
     mock_payload = Mock()
-    lambda_client.invoke20150331.return_value = {
+    lambda_client.invoke.return_value = {
         "StatusCode": 500,
         "Payload": mock_payload,
     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- remove duplicate store update when validating invocation response, the store is updated in `_complete_workflow()`
- use client.invoke instead of invoke20150331

## Dependencies
If this PR requires testing against a specific branch of the Python Language SDK (e.g., for unreleased changes), uncomment and specify the branch below. Otherwise, leave commented to use the main branch.

<!-- PYTHON_LANGUAGE_SDK_BRANCH: main -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
