### PR TITLE
fix(testing-sdk): update WaitDetails to use scheduled_end_timestamp

### DIFF
--- a/.github/workflows/deploy-examples.yml
+++ b/.github/workflows/deploy-examples.yml
@@ -85,6 +85,16 @@ jobs:
           FUNCTION_NAME="${EXAMPLE_NAME_CLEAN}-Python"
         fi
         
+        # Clean up existing function if present to avoid conflicts
+        echo "Cleaning up existing function if present..."
+        aws lambda delete-function \
+          --function-name "$FUNCTION_NAME" \
+          --endpoint-url "$LAMBDA_ENDPOINT" \
+          --region "$AWS_REGION" 2>/dev/null || echo "No existing function to clean up"
+        
+        # Give AWS time to process the deletion
+        sleep 5
+        
         echo "Deploying ${{ matrix.example.name }} as $FUNCTION_NAME"
         hatch run examples:deploy "${{ matrix.example.name }}" --function-name "$FUNCTION_NAME"
         
@@ -95,6 +105,10 @@ jobs:
         echo "FUNCTION_NAME=$FUNCTION_NAME" >> $GITHUB_ENV
         echo "QUALIFIED_FUNCTION_NAME=$QUALIFIED_FUNCTION_NAME" >> $GITHUB_ENV
         echo "VERSION=$VERSION" >> $GITHUB_ENV
+
+        # Wait for function to be ready
+        echo "Waiting for function to be active..."
+        aws lambda wait function-active --function-name "$QUALIFIED_FUNCTION_NAME" --endpoint-url "$LAMBDA_ENDPOINT" --region "$AWS_REGION"
 
     - name: Invoke Lambda function - ${{ matrix.example.name }}
       env:

--- a/examples/test/test_wait.py
+++ b/examples/test/test_wait.py
@@ -21,4 +21,4 @@ def test_wait():
     wait_ops = [op for op in result.operations if op.operation_type.value == "WAIT"]
     assert len(wait_ops) == 1
     wait_op = wait_ops[0]
-    assert wait_op.scheduled_timestamp is not None
+    assert wait_op.scheduled_end_timestamp is not None

--- a/src/aws_durable_execution_sdk_python_testing/checkpoint/processors/base.py
+++ b/src/aws_durable_execution_sdk_python_testing/checkpoint/processors/base.py
@@ -122,12 +122,14 @@ class OperationProcessor:
         """Create WaitDetails from OperationUpdate."""
         if update.operation_type == OperationType.WAIT and update.wait_options:
             if current_operation and current_operation.wait_details:
-                scheduled_timestamp = current_operation.wait_details.scheduled_timestamp
+                scheduled_end_timestamp = (
+                    current_operation.wait_details.scheduled_end_timestamp
+                )
             else:
-                scheduled_timestamp = datetime.datetime.now(
+                scheduled_end_timestamp = datetime.datetime.now(
                     tz=datetime.UTC
                 ) + timedelta(seconds=update.wait_options.wait_seconds)
-            return WaitDetails(scheduled_timestamp=scheduled_timestamp)
+            return WaitDetails(scheduled_end_timestamp=scheduled_end_timestamp)
         return None
 
     def _translate_update_to_operation(

--- a/src/aws_durable_execution_sdk_python_testing/checkpoint/processors/wait.py
+++ b/src/aws_durable_execution_sdk_python_testing/checkpoint/processors/wait.py
@@ -41,12 +41,14 @@ class WaitProcessor(OperationProcessor):
                 wait_seconds = (
                     update.wait_options.wait_seconds if update.wait_options else 0
                 )
-                scheduled_timestamp = datetime.now(UTC) + timedelta(
+                scheduled_end_timestamp = datetime.now(UTC) + timedelta(
                     seconds=wait_seconds
                 )
 
                 # Create WaitDetails with scheduled timestamp
-                wait_details = WaitDetails(scheduled_timestamp=scheduled_timestamp)
+                wait_details = WaitDetails(
+                    scheduled_end_timestamp=scheduled_end_timestamp
+                )
 
                 # Create new operation with wait details
                 wait_operation = Operation(

--- a/src/aws_durable_execution_sdk_python_testing/executor.py
+++ b/src/aws_durable_execution_sdk_python_testing/executor.py
@@ -142,17 +142,15 @@ class Executor(ExecutionObserver):
             durable_execution_name=execution.start_input.execution_name,
             function_arn=f"arn:aws:lambda:us-east-1:123456789012:function:{execution.start_input.function_name}",
             status=status,
-            start_timestamp=execution_op.start_timestamp.timestamp()
+            start_timestamp=execution_op.start_timestamp
             if execution_op.start_timestamp
-            else datetime.now(UTC).timestamp(),
+            else datetime.now(UTC),
             input_payload=execution_op.execution_details.input_payload
             if execution_op.execution_details
             else None,
             result=result,
             error=error,
-            end_timestamp=execution_op.end_timestamp.timestamp()
-            if execution_op.end_timestamp
-            else None,
+            end_timestamp=execution_op.end_timestamp,
             version="1.0",
         )
 
@@ -223,12 +221,10 @@ class Executor(ExecutionObserver):
                 durable_execution_name=execution.start_input.execution_name,
                 function_arn=f"arn:aws:lambda:us-east-1:123456789012:function:{execution.start_input.function_name}",
                 status=execution_status,
-                start_timestamp=execution_op.start_timestamp.timestamp()
+                start_timestamp=execution_op.start_timestamp
                 if execution_op.start_timestamp
-                else datetime.now(UTC).timestamp(),
-                end_timestamp=execution_op.end_timestamp.timestamp()
-                if execution_op.end_timestamp
-                else None,
+                else datetime.now(UTC),
+                end_timestamp=execution_op.end_timestamp,
             )
             filtered_executions.append(execution_summary)
 
@@ -333,7 +329,7 @@ class Executor(ExecutionObserver):
         # Stop the execution
         self.fail_execution(execution_arn, stop_error)
 
-        return StopDurableExecutionResponse(end_timestamp=datetime.now(UTC).timestamp())
+        return StopDurableExecutionResponse(stop_timestamp=datetime.now(UTC))
 
     def get_execution_state(
         self,

--- a/src/aws_durable_execution_sdk_python_testing/model.py
+++ b/src/aws_durable_execution_sdk_python_testing/model.py
@@ -3,7 +3,11 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+
+if TYPE_CHECKING:
+    import datetime
 
 # Import existing types from the main SDK - REUSE EVERYTHING POSSIBLE
 from aws_durable_execution_sdk_python.lambda_service import (
@@ -156,11 +160,11 @@ class GetDurableExecutionResponse:
     durable_execution_name: str
     function_arn: str
     status: str
-    start_timestamp: float
+    start_timestamp: datetime.datetime
     input_payload: str | None = None
     result: str | None = None
     error: ErrorObject | None = None
-    end_timestamp: float | None = None
+    end_timestamp: datetime.datetime | None = None
     version: str | None = None
 
     @classmethod
@@ -213,8 +217,8 @@ class Execution:
     durable_execution_name: str
     function_arn: str
     status: str
-    start_timestamp: float
-    end_timestamp: float | None = None
+    start_timestamp: datetime.datetime
+    end_timestamp: datetime.datetime | None = None
 
     @classmethod
     def from_dict(cls, data: dict) -> Execution:
@@ -350,14 +354,14 @@ class StopDurableExecutionRequest:
 class StopDurableExecutionResponse:
     """Response from stopping a durable execution."""
 
-    end_timestamp: float
+    stop_timestamp: datetime.datetime
 
     @classmethod
     def from_dict(cls, data: dict) -> StopDurableExecutionResponse:
-        return cls(end_timestamp=data["EndTimestamp"])
+        return cls(stop_timestamp=data["StopTimestamp"])
 
     def to_dict(self) -> dict[str, Any]:
-        return {"EndTimestamp": self.end_timestamp}
+        return {"StopTimestamp": self.stop_timestamp}
 
 
 @dataclass(frozen=True)
@@ -676,7 +680,7 @@ class WaitStartedDetails:
     """Wait started event details."""
 
     duration: int | None = None
-    scheduled_end_timestamp: str | None = None
+    scheduled_end_timestamp: datetime.datetime | None = None  # Already correct!
 
     @classmethod
     def from_dict(cls, data: dict) -> WaitStartedDetails:
@@ -1010,7 +1014,7 @@ class Event:
     """Event structure from Smithy model."""
 
     event_type: str
-    event_timestamp: str
+    event_timestamp: datetime.datetime
     sub_type: str | None = None
     event_id: int = 1
     operation_id: str | None = None
@@ -1328,8 +1332,8 @@ class ListDurableExecutionsByFunctionRequest:
     qualifier: str | None = None
     durable_execution_name: str | None = None
     status_filter: list[str] | None = None
-    time_after: str | None = None
-    time_before: str | None = None
+    started_after: str | None = None
+    started_before: str | None = None
     marker: str | None = None
     max_items: int = 0
     reverse_order: bool | None = None
@@ -1341,8 +1345,8 @@ class ListDurableExecutionsByFunctionRequest:
             qualifier=data.get("Qualifier"),
             durable_execution_name=data.get("DurableExecutionName"),
             status_filter=data.get("StatusFilter"),
-            time_after=data.get("TimeAfter"),
-            time_before=data.get("TimeBefore"),
+            started_after=data.get("StartedAfter"),
+            started_before=data.get("StartedBefore"),
             marker=data.get("Marker"),
             max_items=data.get("MaxItems", 0),
             reverse_order=data.get("ReverseOrder"),
@@ -1356,10 +1360,10 @@ class ListDurableExecutionsByFunctionRequest:
             result["DurableExecutionName"] = self.durable_execution_name
         if self.status_filter is not None:
             result["StatusFilter"] = self.status_filter
-        if self.time_after is not None:
-            result["TimeAfter"] = self.time_after
-        if self.time_before is not None:
-            result["TimeBefore"] = self.time_before
+        if self.started_after is not None:
+            result["StartedAfter"] = self.started_after
+        if self.started_before is not None:
+            result["StartedBefore"] = self.started_before
         if self.marker is not None:
             result["Marker"] = self.marker
         if self.max_items is not None:

--- a/src/aws_durable_execution_sdk_python_testing/runner.py
+++ b/src/aws_durable_execution_sdk_python_testing/runner.py
@@ -267,7 +267,7 @@ class StepOperation(ContextOperation):
 
 @dataclass(frozen=True)
 class WaitOperation(Operation):
-    scheduled_timestamp: datetime.datetime | None = None
+    scheduled_end_timestamp: datetime.datetime | None = None
 
     @staticmethod
     def from_svc_operation(
@@ -286,8 +286,8 @@ class WaitOperation(Operation):
             sub_type=operation.sub_type,
             start_timestamp=operation.start_timestamp,
             end_timestamp=operation.end_timestamp,
-            scheduled_timestamp=(
-                operation.wait_details.scheduled_timestamp
+            scheduled_end_timestamp=(
+                operation.wait_details.scheduled_end_timestamp
                 if operation.wait_details
                 else None
             ),

--- a/src/aws_durable_execution_sdk_python_testing/web/handlers.py
+++ b/src/aws_durable_execution_sdk_python_testing/web/handlers.py
@@ -578,9 +578,9 @@ class ListDurableExecutionsByFunctionHandler(EndpointHandler):
             if status_filter := self._parse_query_param(request, "statusFilter"):
                 query_params["StatusFilter"] = [status_filter]  # Convert to list
             if time_after := self._parse_query_param(request, "timeAfter"):
-                query_params["TimeAfter"] = time_after
+                query_params["StartedAfter"] = time_after
             if time_before := self._parse_query_param(request, "timeBefore"):
-                query_params["TimeBefore"] = time_before
+                query_params["StartedBefore"] = time_before
             if marker := self._parse_query_param(request, "marker"):
                 query_params["Marker"] = marker
             if max_items_str := self._parse_query_param(request, "maxItems"):
@@ -608,8 +608,8 @@ class ListDurableExecutionsByFunctionHandler(EndpointHandler):
                     status_filter=list_request.status_filter[0]
                     if list_request.status_filter
                     else None,
-                    time_after=list_request.time_after,
-                    time_before=list_request.time_before,
+                    time_after=list_request.started_after,
+                    time_before=list_request.started_before,
                     marker=list_request.marker,
                     max_items=list_request.max_items
                     if list_request.max_items > 0

--- a/tests/checkpoint/processors/base_test.py
+++ b/tests/checkpoint/processors/base_test.py
@@ -320,7 +320,7 @@ def test_create_wait_details_with_current_operation():
     processor = MockProcessor()
     scheduled_time = datetime.datetime.now(tz=datetime.UTC)
     current_op = Mock()
-    current_op.wait_details = WaitDetails(scheduled_timestamp=scheduled_time)
+    current_op.wait_details = WaitDetails(scheduled_end_timestamp=scheduled_time)
 
     wait_options = WaitOptions(wait_seconds=30)
     update = OperationUpdate(
@@ -333,7 +333,7 @@ def test_create_wait_details_with_current_operation():
     result = processor.create_wait_details(update, current_op)
 
     assert isinstance(result, WaitDetails)
-    assert result.scheduled_timestamp == scheduled_time
+    assert result.scheduled_end_timestamp == scheduled_time
 
 
 def test_create_wait_details_without_current_operation():
@@ -349,7 +349,7 @@ def test_create_wait_details_without_current_operation():
     result = processor.create_wait_details(update, None)
 
     assert isinstance(result, WaitDetails)
-    assert result.scheduled_timestamp > datetime.datetime.now(tz=datetime.UTC)
+    assert result.scheduled_end_timestamp > datetime.datetime.now(tz=datetime.UTC)
 
 
 def test_create_wait_details_non_wait_type():

--- a/tests/checkpoint/processors/wait_test.py
+++ b/tests/checkpoint/processors/wait_test.py
@@ -67,7 +67,7 @@ def test_process_start_action():
     assert result.status == OperationStatus.STARTED
     assert result.name == "test-wait"
     assert result.wait_details is not None
-    assert result.wait_details.scheduled_timestamp > datetime.now(UTC)
+    assert result.wait_details.scheduled_end_timestamp > datetime.now(UTC)
 
     assert len(notifier.wait_timer_calls) == 1
     assert notifier.wait_timer_calls[0] == (execution_arn, "wait-123", 30)
@@ -269,7 +269,7 @@ def test_wait_details_created_correctly():
     before_time = datetime.now(UTC)
     result = processor.process(update, None, notifier, execution_arn)
 
-    assert result.wait_details.scheduled_timestamp > before_time
+    assert result.wait_details.scheduled_end_timestamp > before_time
 
 
 def test_no_completed_or_failed_calls():

--- a/tests/executor_test.py
+++ b/tests/executor_test.py
@@ -1860,7 +1860,7 @@ def test_stop_execution(executor, mock_store):
 
     mock_store.load.assert_called_once_with("test-arn")
     mock_fail.assert_called_once()
-    assert result.end_timestamp is not None
+    assert result.stop_timestamp is not None
 
 
 def test_stop_execution_already_complete(executor, mock_store):

--- a/tests/model_test.py
+++ b/tests/model_test.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import datetime
+
 import pytest
 
 from aws_durable_execution_sdk_python_testing.exceptions import (
@@ -62,6 +64,13 @@ from aws_durable_execution_sdk_python_testing.model import (
     WaitStartedDetails,
     WaitSucceededDetails,
 )
+
+
+# Test timestamp constants
+TIMESTAMP_2023_01_01_00_00 = datetime.datetime(2023, 1, 1, 0, 0, 0, tzinfo=datetime.UTC)
+TIMESTAMP_2023_01_01_00_01 = datetime.datetime(2023, 1, 1, 0, 1, 0, tzinfo=datetime.UTC)
+TIMESTAMP_2023_01_01_00_02 = datetime.datetime(2023, 1, 1, 0, 2, 0, tzinfo=datetime.UTC)
+TIMESTAMP_2023_01_02_00_00 = datetime.datetime(2023, 1, 2, 0, 0, 0, tzinfo=datetime.UTC)
 
 
 def test_start_durable_execution_input_serialization():
@@ -180,11 +189,11 @@ def test_get_durable_execution_response_serialization():
         "DurableExecutionName": "test-execution",
         "FunctionArn": "arn:aws:lambda:us-east-1:123456789012:function:my-function",
         "Status": "SUCCEEDED",
-        "StartTimestamp": "2023-01-01T00:00:00Z",
+        "StartTimestamp": TIMESTAMP_2023_01_01_00_00,
         "InputPayload": "test-input",
         "Result": "test-result",
         "Error": {"ErrorMessage": "test error"},
-        "EndTimestamp": "2023-01-01T00:01:00Z",
+        "EndTimestamp": TIMESTAMP_2023_01_01_00_01,
         "Version": "1.0",
     }
 
@@ -199,11 +208,11 @@ def test_get_durable_execution_response_serialization():
         == "arn:aws:lambda:us-east-1:123456789012:function:my-function"
     )
     assert response_obj.status == "SUCCEEDED"
-    assert response_obj.start_timestamp == "2023-01-01T00:00:00Z"
+    assert response_obj.start_timestamp == TIMESTAMP_2023_01_01_00_00
     assert response_obj.input_payload == "test-input"
     assert response_obj.result == "test-result"
     assert response_obj.error.message == "test error"
-    assert response_obj.end_timestamp == "2023-01-01T00:01:00Z"
+    assert response_obj.end_timestamp == TIMESTAMP_2023_01_01_00_01
     assert response_obj.version == "1.0"
 
     result_data = response_obj.to_dict()
@@ -221,7 +230,7 @@ def test_get_durable_execution_response_minimal():
         "DurableExecutionName": "test-execution",
         "FunctionArn": "arn:aws:lambda:us-east-1:123456789012:function:my-function",
         "Status": "RUNNING",
-        "StartTimestamp": "2023-01-01T00:00:00Z",
+        "StartTimestamp": TIMESTAMP_2023_01_01_00_00,
     }
 
     response_obj = GetDurableExecutionResponse.from_dict(data)
@@ -242,8 +251,8 @@ def test_list_durable_executions_request_serialization():
         "FunctionVersion": "$LATEST",
         "DurableExecutionName": "test-execution",
         "StatusFilter": ["RUNNING", "SUCCEEDED"],
-        "TimeAfter": "2023-01-01T00:00:00Z",
-        "TimeBefore": "2023-01-02T00:00:00Z",
+        "TimeAfter": TIMESTAMP_2023_01_01_00_00,
+        "TimeBefore": TIMESTAMP_2023_01_02_00_00,
         "Marker": "marker-123",
         "MaxItems": 10,
         "ReverseOrder": True,
@@ -254,8 +263,8 @@ def test_list_durable_executions_request_serialization():
     assert request_obj.function_version == "$LATEST"
     assert request_obj.durable_execution_name == "test-execution"
     assert request_obj.status_filter == ["RUNNING", "SUCCEEDED"]
-    assert request_obj.time_after == "2023-01-01T00:00:00Z"
-    assert request_obj.time_before == "2023-01-02T00:00:00Z"
+    assert request_obj.time_after == TIMESTAMP_2023_01_01_00_00
+    assert request_obj.time_before == TIMESTAMP_2023_01_02_00_00
     assert request_obj.marker == "marker-123"
     assert request_obj.max_items == 10
     assert request_obj.reverse_order is True
@@ -295,8 +304,8 @@ def test_durable_execution_summary_serialization():
         "DurableExecutionArn": "arn:aws:lambda:us-east-1:123456789012:function:my-function:execution:test",
         "DurableExecutionName": "test-execution",
         "Status": "SUCCEEDED",
-        "StartTimestamp": "2023-01-01T00:00:00Z",
-        "EndTimestamp": "2023-01-01T00:01:00Z",
+        "StartTimestamp": TIMESTAMP_2023_01_01_00_00,
+        "EndTimestamp": TIMESTAMP_2023_01_01_00_01,
     }
 
     summary_obj = Execution.from_dict(data)
@@ -306,8 +315,8 @@ def test_durable_execution_summary_serialization():
     )
     assert summary_obj.durable_execution_name == "test-execution"
     assert summary_obj.status == "SUCCEEDED"
-    assert summary_obj.start_timestamp == "2023-01-01T00:00:00Z"
-    assert summary_obj.end_timestamp == "2023-01-01T00:01:00Z"
+    assert summary_obj.start_timestamp == TIMESTAMP_2023_01_01_00_00
+    assert summary_obj.end_timestamp == TIMESTAMP_2023_01_01_00_01
 
     result_data = summary_obj.to_dict()
     assert result_data == data
@@ -323,7 +332,7 @@ def test_durable_execution_summary_no_end_timestamp():
         "DurableExecutionArn": "arn:aws:lambda:us-east-1:123456789012:function:my-function:execution:test",
         "DurableExecutionName": "test-execution",
         "Status": "RUNNING",
-        "StartTimestamp": "2023-01-01T00:00:00Z",
+        "StartTimestamp": TIMESTAMP_2023_01_01_00_00,
     }
 
     summary_obj = Execution.from_dict(data)
@@ -341,14 +350,14 @@ def test_list_durable_executions_response_serialization():
                 "DurableExecutionArn": "arn:aws:lambda:us-east-1:123456789012:function:my-function:execution:test1",
                 "DurableExecutionName": "test-execution-1",
                 "Status": "SUCCEEDED",
-                "StartTimestamp": "2023-01-01T00:00:00Z",
-                "EndTimestamp": "2023-01-01T00:01:00Z",
+                "StartTimestamp": TIMESTAMP_2023_01_01_00_00,
+                "EndTimestamp": TIMESTAMP_2023_01_01_00_01,
             },
             {
                 "DurableExecutionArn": "arn:aws:lambda:us-east-1:123456789012:function:my-function:execution:test2",
                 "DurableExecutionName": "test-execution-2",
                 "Status": "RUNNING",
-                "StartTimestamp": "2023-01-01T00:02:00Z",
+                "StartTimestamp": TIMESTAMP_2023_01_01_00_02,
             },
         ],
         "NextMarker": "next-marker-123",
@@ -421,10 +430,10 @@ def test_stop_durable_execution_request_minimal():
 
 def test_stop_durable_execution_response_serialization():
     """Test StopDurableExecutionResponse from_dict/to_dict round-trip."""
-    data = {"EndTimestamp": "2023-01-01T00:01:00Z"}
+    data = {"StopTimestamp": TIMESTAMP_2023_01_01_00_01}
 
     response_obj = StopDurableExecutionResponse.from_dict(data)
-    assert response_obj.end_timestamp == "2023-01-01T00:01:00Z"
+    assert response_obj.stop_timestamp == TIMESTAMP_2023_01_01_00_01
 
     result_data = response_obj.to_dict()
     assert result_data == data
@@ -573,7 +582,7 @@ def test_execution_event_serialization():
     data = {
         "EventType": "ExecutionStarted",
         "EventId": 123,
-        "EventTimestamp": "2023-01-01T00:00:00Z",
+        "EventTimestamp": TIMESTAMP_2023_01_01_00_00,
         "SubType": "UserInitiated",
         "Id": "op-123",
         "Name": "test-operation",
@@ -587,7 +596,7 @@ def test_execution_event_serialization():
     event_obj = Event.from_dict(data)
     assert event_obj.event_type == "ExecutionStarted"
     assert event_obj.event_id == 123
-    assert event_obj.event_timestamp == "2023-01-01T00:00:00Z"
+    assert event_obj.event_timestamp == TIMESTAMP_2023_01_01_00_00
     assert event_obj.sub_type == "UserInitiated"
     assert event_obj.operation_id == "op-123"
     assert event_obj.name == "test-operation"
@@ -608,7 +617,7 @@ def test_execution_event_minimal():
     """Test Event with only required fields."""
     data = {
         "EventType": "ExecutionStarted",
-        "EventTimestamp": "2023-01-01T00:00:00Z",
+        "EventTimestamp": TIMESTAMP_2023_01_01_00_00,
     }
 
     event_obj = Event.from_dict(data)
@@ -623,7 +632,7 @@ def test_execution_event_minimal():
     # The result should include the default EventId
     expected_data = {
         "EventType": "ExecutionStarted",
-        "EventTimestamp": "2023-01-01T00:00:00Z",
+        "EventTimestamp": TIMESTAMP_2023_01_01_00_00,
         "EventId": 1,
     }
     assert result_data == expected_data
@@ -636,12 +645,12 @@ def test_get_durable_execution_history_response_serialization():
             {
                 "EventType": "ExecutionStarted",
                 "EventId": 1,
-                "EventTimestamp": "2023-01-01T00:00:00Z",
+                "EventTimestamp": TIMESTAMP_2023_01_01_00_00,
             },
             {
                 "EventType": "ExecutionSucceeded",
                 "EventId": 2,
-                "EventTimestamp": "2023-01-01T00:01:00Z",
+                "EventTimestamp": TIMESTAMP_2023_01_01_00_01,
                 "ExecutionSucceededDetails": {
                     "Result": {"Payload": "success", "Truncated": False}
                 },
@@ -686,8 +695,8 @@ def test_list_durable_executions_by_function_request_serialization():
         "FunctionName": "my-function",
         "Qualifier": "$LATEST",
         "StatusFilter": ["RUNNING", "SUCCEEDED"],
-        "TimeAfter": "2023-01-01T00:00:00Z",
-        "TimeBefore": "2023-01-02T00:00:00Z",
+        "StartedAfter": TIMESTAMP_2023_01_01_00_00,
+        "StartedBefore": TIMESTAMP_2023_01_02_00_00,
         "Marker": "marker-123",
         "MaxItems": 10,
         "ReverseOrder": True,
@@ -697,8 +706,8 @@ def test_list_durable_executions_by_function_request_serialization():
     assert request_obj.function_name == "my-function"
     assert request_obj.qualifier == "$LATEST"
     assert request_obj.status_filter == ["RUNNING", "SUCCEEDED"]
-    assert request_obj.time_after == "2023-01-01T00:00:00Z"
-    assert request_obj.time_before == "2023-01-02T00:00:00Z"
+    assert request_obj.started_after == TIMESTAMP_2023_01_01_00_00
+    assert request_obj.started_before == TIMESTAMP_2023_01_02_00_00
     assert request_obj.marker == "marker-123"
     assert request_obj.max_items == 10
     assert request_obj.reverse_order is True
@@ -718,8 +727,8 @@ def test_list_durable_executions_by_function_request_minimal():
     request_obj = ListDurableExecutionsByFunctionRequest.from_dict(data)
     assert request_obj.qualifier is None
     assert request_obj.status_filter is None
-    assert request_obj.time_after is None
-    assert request_obj.time_before is None
+    assert request_obj.started_after is None
+    assert request_obj.started_before is None
     assert request_obj.marker is None
     assert request_obj.max_items == 0  # Default value from Smithy
     assert request_obj.reverse_order is None
@@ -738,8 +747,8 @@ def test_list_durable_executions_by_function_response_serialization():
                 "DurableExecutionArn": "arn:aws:lambda:us-east-1:123456789012:function:my-function:execution:test1",
                 "DurableExecutionName": "test-execution-1",
                 "Status": "SUCCEEDED",
-                "StartTimestamp": "2023-01-01T00:00:00Z",
-                "EndTimestamp": "2023-01-01T00:01:00Z",
+                "StartTimestamp": TIMESTAMP_2023_01_01_00_00,
+                "EndTimestamp": TIMESTAMP_2023_01_01_00_01,
             }
         ],
         "NextMarker": "next-marker-123",
@@ -1189,8 +1198,8 @@ def test_execution_backward_compatibility_empty_function_arn():
         "DurableExecutionArn": "arn:aws:lambda:us-east-1:123456789012:function:my-function:execution:test",
         "DurableExecutionName": "test-execution",
         "Status": "SUCCEEDED",
-        "StartTimestamp": "2023-01-01T00:00:00Z",
-        "EndTimestamp": "2023-01-01T00:01:00Z",
+        "StartTimestamp": TIMESTAMP_2023_01_01_00_00,
+        "EndTimestamp": TIMESTAMP_2023_01_01_00_01,
     }
 
     execution_obj = Execution.from_dict(data)
@@ -1204,8 +1213,8 @@ def test_execution_backward_compatibility_empty_function_arn():
         "DurableExecutionArn": "arn:aws:lambda:us-east-1:123456789012:function:my-function:execution:test",
         "DurableExecutionName": "test-execution",
         "Status": "SUCCEEDED",
-        "StartTimestamp": "2023-01-01T00:00:00Z",
-        "EndTimestamp": "2023-01-01T00:01:00Z",
+        "StartTimestamp": TIMESTAMP_2023_01_01_00_00,
+        "EndTimestamp": TIMESTAMP_2023_01_01_00_01,
     }
     assert result_data == expected_data
 
@@ -1217,8 +1226,8 @@ def test_execution_with_function_arn():
         "DurableExecutionName": "test-execution",
         "FunctionArn": "arn:aws:lambda:us-east-1:123456789012:function:my-function",
         "Status": "SUCCEEDED",
-        "StartTimestamp": "2023-01-01T00:00:00Z",
-        "EndTimestamp": "2023-01-01T00:01:00Z",
+        "StartTimestamp": TIMESTAMP_2023_01_01_00_00,
+        "EndTimestamp": TIMESTAMP_2023_01_01_00_01,
     }
 
     execution_obj = Execution.from_dict(data)
@@ -1259,7 +1268,7 @@ def test_list_durable_executions_request_partial_fields():
         function_version=None,
         durable_execution_name="test-execution",
         status_filter=None,
-        time_after="2023-01-01T00:00:00Z",
+        time_after=TIMESTAMP_2023_01_01_00_00,
         time_before=None,
         marker="marker-123",
         max_items=10,
@@ -1270,7 +1279,7 @@ def test_list_durable_executions_request_partial_fields():
     expected_data = {
         "FunctionName": "my-function",
         "DurableExecutionName": "test-execution",
-        "TimeAfter": "2023-01-01T00:00:00Z",
+        "TimeAfter": TIMESTAMP_2023_01_01_00_00,
         "Marker": "marker-123",
         "MaxItems": 10,
     }
@@ -1657,12 +1666,12 @@ def test_wait_started_details_serialization():
     """Test WaitStartedDetails from_dict/to_dict round-trip."""
     data = {
         "Duration": 60,
-        "ScheduledEndTimestamp": "2023-01-01T00:01:00Z",
+        "ScheduledEndTimestamp": TIMESTAMP_2023_01_01_00_01,
     }
 
     details = WaitStartedDetails.from_dict(data)
     assert details.duration == 60
-    assert details.scheduled_end_timestamp == "2023-01-01T00:01:00Z"
+    assert details.scheduled_end_timestamp == TIMESTAMP_2023_01_01_00_01
 
     result_data = details.to_dict()
     assert result_data == data
@@ -2121,7 +2130,7 @@ def test_event_with_execution_succeeded_details():
     """Test Event with ExecutionSucceededDetails."""
     data = {
         "EventType": "ExecutionSucceeded",
-        "EventTimestamp": "2023-01-01T00:01:00Z",
+        "EventTimestamp": TIMESTAMP_2023_01_01_00_01,
         "ExecutionSucceededDetails": {
             "Result": {"Payload": "success", "Truncated": False}
         },
@@ -2135,7 +2144,7 @@ def test_event_with_execution_succeeded_details():
     result_data = event_obj.to_dict()
     expected_data = {
         "EventType": "ExecutionSucceeded",
-        "EventTimestamp": "2023-01-01T00:01:00Z",
+        "EventTimestamp": TIMESTAMP_2023_01_01_00_01,
         "EventId": 1,  # Default value
         "ExecutionSucceededDetails": {
             "Result": {"Payload": "success", "Truncated": False}
@@ -2148,7 +2157,7 @@ def test_event_with_execution_failed_details():
     """Test Event with ExecutionFailedDetails."""
     data = {
         "EventType": "ExecutionFailed",
-        "EventTimestamp": "2023-01-01T00:01:00Z",
+        "EventTimestamp": TIMESTAMP_2023_01_01_00_01,
         "ExecutionFailedDetails": {
             "Error": {
                 "Payload": {"ErrorMessage": "execution failed"},
@@ -2167,7 +2176,7 @@ def test_event_with_execution_failed_details():
     result_data = event_obj.to_dict()
     expected_data = {
         "EventType": "ExecutionFailed",
-        "EventTimestamp": "2023-01-01T00:01:00Z",
+        "EventTimestamp": TIMESTAMP_2023_01_01_00_01,
         "EventId": 1,
         "ExecutionFailedDetails": {
             "Error": {
@@ -2183,7 +2192,7 @@ def test_event_with_execution_timed_out_details():
     """Test Event with ExecutionTimedOutDetails."""
     data = {
         "EventType": "ExecutionTimedOut",
-        "EventTimestamp": "2023-01-01T00:01:00Z",
+        "EventTimestamp": TIMESTAMP_2023_01_01_00_01,
         "ExecutionTimedOutDetails": {
             "Error": {
                 "Payload": {"ErrorMessage": "execution timed out"},
@@ -2203,7 +2212,7 @@ def test_event_with_execution_timed_out_details():
     result_data = event_obj.to_dict()
     expected_data = {
         "EventType": "ExecutionTimedOut",
-        "EventTimestamp": "2023-01-01T00:01:00Z",
+        "EventTimestamp": TIMESTAMP_2023_01_01_00_01,
         "EventId": 1,
         "ExecutionTimedOutDetails": {
             "Error": {
@@ -2219,7 +2228,7 @@ def test_event_with_execution_stopped_details():
     """Test Event with ExecutionStoppedDetails."""
     data = {
         "EventType": "ExecutionStopped",
-        "EventTimestamp": "2023-01-01T00:01:00Z",
+        "EventTimestamp": TIMESTAMP_2023_01_01_00_01,
         "ExecutionStoppedDetails": {
             "Error": {
                 "Payload": {"ErrorMessage": "execution stopped"},
@@ -2238,7 +2247,7 @@ def test_event_with_execution_stopped_details():
     result_data = event_obj.to_dict()
     expected_data = {
         "EventType": "ExecutionStopped",
-        "EventTimestamp": "2023-01-01T00:01:00Z",
+        "EventTimestamp": TIMESTAMP_2023_01_01_00_01,
         "EventId": 1,
         "ExecutionStoppedDetails": {
             "Error": {
@@ -2256,7 +2265,7 @@ def test_event_with_context_started_details():
     # we need to provide a non-empty dict or test without the key
     data = {
         "EventType": "ContextStarted",
-        "EventTimestamp": "2023-01-01T00:01:00Z",
+        "EventTimestamp": TIMESTAMP_2023_01_01_00_01,
         "ContextStartedDetails": {"dummy": "value"},  # Non-empty to be truthy
     }
 
@@ -2267,7 +2276,7 @@ def test_event_with_context_started_details():
     result_data = event_obj.to_dict()
     expected_data = {
         "EventType": "ContextStarted",
-        "EventTimestamp": "2023-01-01T00:01:00Z",
+        "EventTimestamp": TIMESTAMP_2023_01_01_00_01,
         "EventId": 1,
         "ContextStartedDetails": {},  # to_dict() returns empty dict
     }
@@ -2278,7 +2287,7 @@ def test_event_with_context_succeeded_details():
     """Test Event with ContextSucceededDetails."""
     data = {
         "EventType": "ContextSucceeded",
-        "EventTimestamp": "2023-01-01T00:01:00Z",
+        "EventTimestamp": TIMESTAMP_2023_01_01_00_01,
         "ContextSucceededDetails": {
             "Result": {"Payload": "context result", "Truncated": False}
         },
@@ -2292,7 +2301,7 @@ def test_event_with_context_succeeded_details():
     result_data = event_obj.to_dict()
     expected_data = {
         "EventType": "ContextSucceeded",
-        "EventTimestamp": "2023-01-01T00:01:00Z",
+        "EventTimestamp": TIMESTAMP_2023_01_01_00_01,
         "EventId": 1,
         "ContextSucceededDetails": {
             "Result": {"Payload": "context result", "Truncated": False}
@@ -2305,7 +2314,7 @@ def test_event_with_context_failed_details():
     """Test Event with ContextFailedDetails."""
     data = {
         "EventType": "ContextFailed",
-        "EventTimestamp": "2023-01-01T00:01:00Z",
+        "EventTimestamp": TIMESTAMP_2023_01_01_00_01,
         "ContextFailedDetails": {
             "Error": {"Payload": {"ErrorMessage": "context failed"}, "Truncated": False}
         },
@@ -2319,7 +2328,7 @@ def test_event_with_context_failed_details():
     result_data = event_obj.to_dict()
     expected_data = {
         "EventType": "ContextFailed",
-        "EventTimestamp": "2023-01-01T00:01:00Z",
+        "EventTimestamp": TIMESTAMP_2023_01_01_00_01,
         "EventId": 1,
         "ContextFailedDetails": {
             "Error": {"Payload": {"ErrorMessage": "context failed"}, "Truncated": False}
@@ -2332,10 +2341,10 @@ def test_event_with_wait_started_details():
     """Test Event with WaitStartedDetails."""
     data = {
         "EventType": "WaitStarted",
-        "EventTimestamp": "2023-01-01T00:01:00Z",
+        "EventTimestamp": TIMESTAMP_2023_01_01_00_01,
         "WaitStartedDetails": {
             "Duration": 60,
-            "ScheduledEndTimestamp": "2023-01-01T00:02:00Z",
+            "ScheduledEndTimestamp": TIMESTAMP_2023_01_01_00_02,
         },
     }
 
@@ -2347,11 +2356,11 @@ def test_event_with_wait_started_details():
     result_data = event_obj.to_dict()
     expected_data = {
         "EventType": "WaitStarted",
-        "EventTimestamp": "2023-01-01T00:01:00Z",
+        "EventTimestamp": TIMESTAMP_2023_01_01_00_01,
         "EventId": 1,
         "WaitStartedDetails": {
             "Duration": 60,
-            "ScheduledEndTimestamp": "2023-01-01T00:02:00Z",
+            "ScheduledEndTimestamp": TIMESTAMP_2023_01_01_00_02,
         },
     }
     assert result_data == expected_data
@@ -2361,7 +2370,7 @@ def test_event_with_wait_succeeded_details():
     """Test Event with WaitSucceededDetails."""
     data = {
         "EventType": "WaitSucceeded",
-        "EventTimestamp": "2023-01-01T00:01:00Z",
+        "EventTimestamp": TIMESTAMP_2023_01_01_00_01,
         "WaitSucceededDetails": {"Duration": 60},
     }
 
@@ -2373,7 +2382,7 @@ def test_event_with_wait_succeeded_details():
     result_data = event_obj.to_dict()
     expected_data = {
         "EventType": "WaitSucceeded",
-        "EventTimestamp": "2023-01-01T00:01:00Z",
+        "EventTimestamp": TIMESTAMP_2023_01_01_00_01,
         "EventId": 1,
         "WaitSucceededDetails": {"Duration": 60},
     }
@@ -2384,7 +2393,7 @@ def test_event_with_wait_cancelled_details():
     """Test Event with WaitCancelledDetails."""
     data = {
         "EventType": "WaitCancelled",
-        "EventTimestamp": "2023-01-01T00:01:00Z",
+        "EventTimestamp": TIMESTAMP_2023_01_01_00_01,
         "WaitCancelledDetails": {
             "Error": {"Payload": {"ErrorMessage": "wait cancelled"}, "Truncated": False}
         },
@@ -2398,7 +2407,7 @@ def test_event_with_wait_cancelled_details():
     result_data = event_obj.to_dict()
     expected_data = {
         "EventType": "WaitCancelled",
-        "EventTimestamp": "2023-01-01T00:01:00Z",
+        "EventTimestamp": TIMESTAMP_2023_01_01_00_01,
         "EventId": 1,
         "WaitCancelledDetails": {
             "Error": {"Payload": {"ErrorMessage": "wait cancelled"}, "Truncated": False}
@@ -2413,7 +2422,7 @@ def test_event_with_step_started_details():
     # we need to provide a non-empty dict or test without the key
     data = {
         "EventType": "StepStarted",
-        "EventTimestamp": "2023-01-01T00:01:00Z",
+        "EventTimestamp": TIMESTAMP_2023_01_01_00_01,
         "StepStartedDetails": {"dummy": "value"},  # Non-empty to be truthy
     }
 
@@ -2424,7 +2433,7 @@ def test_event_with_step_started_details():
     result_data = event_obj.to_dict()
     expected_data = {
         "EventType": "StepStarted",
-        "EventTimestamp": "2023-01-01T00:01:00Z",
+        "EventTimestamp": TIMESTAMP_2023_01_01_00_01,
         "EventId": 1,
         "StepStartedDetails": {},  # to_dict() returns empty dict
     }
@@ -2435,7 +2444,7 @@ def test_event_with_step_succeeded_details():
     """Test Event with StepSucceededDetails."""
     data = {
         "EventType": "StepSucceeded",
-        "EventTimestamp": "2023-01-01T00:01:00Z",
+        "EventTimestamp": TIMESTAMP_2023_01_01_00_01,
         "StepSucceededDetails": {
             "Result": {"Payload": "step result", "Truncated": False},
             "RetryDetails": {"CurrentAttempt": 1},
@@ -2450,7 +2459,7 @@ def test_event_with_step_succeeded_details():
     result_data = event_obj.to_dict()
     expected_data = {
         "EventType": "StepSucceeded",
-        "EventTimestamp": "2023-01-01T00:01:00Z",
+        "EventTimestamp": TIMESTAMP_2023_01_01_00_01,
         "EventId": 1,
         "StepSucceededDetails": {
             "Result": {"Payload": "step result", "Truncated": False},
@@ -2464,7 +2473,7 @@ def test_event_with_step_failed_details():
     """Test Event with StepFailedDetails."""
     data = {
         "EventType": "StepFailed",
-        "EventTimestamp": "2023-01-01T00:01:00Z",
+        "EventTimestamp": TIMESTAMP_2023_01_01_00_01,
         "StepFailedDetails": {
             "Error": {"Payload": {"ErrorMessage": "step failed"}, "Truncated": False},
             "RetryDetails": {"CurrentAttempt": 2, "NextAttemptDelaySeconds": 30},
@@ -2479,7 +2488,7 @@ def test_event_with_step_failed_details():
     result_data = event_obj.to_dict()
     expected_data = {
         "EventType": "StepFailed",
-        "EventTimestamp": "2023-01-01T00:01:00Z",
+        "EventTimestamp": TIMESTAMP_2023_01_01_00_01,
         "EventId": 1,
         "StepFailedDetails": {
             "Error": {"Payload": {"ErrorMessage": "step failed"}, "Truncated": False},
@@ -2493,7 +2502,7 @@ def test_event_with_invoke_started_details():
     """Test Event with ChainedInvokeStartedDetails."""
     data = {
         "EventType": "ChainedInvokeStarted",
-        "EventTimestamp": "2023-01-01T00:01:00Z",
+        "EventTimestamp": TIMESTAMP_2023_01_01_00_01,
         "ChainedInvokeStartedDetails": {
             "Input": {"Payload": "invoke input", "Truncated": False},
             "FunctionArn": "arn:aws:lambda:us-east-1:123456789012:function:target",
@@ -2508,7 +2517,7 @@ def test_event_with_invoke_started_details():
     result_data = event_obj.to_dict()
     expected_data = {
         "EventType": "ChainedInvokeStarted",
-        "EventTimestamp": "2023-01-01T00:01:00Z",
+        "EventTimestamp": TIMESTAMP_2023_01_01_00_01,
         "EventId": 1,
         "ChainedInvokeStartedDetails": {
             "Input": {"Payload": "invoke input", "Truncated": False},
@@ -2522,7 +2531,7 @@ def test_event_with_invoke_succeeded_details():
     """Test Event with ChainedInvokeSucceededDetails."""
     data = {
         "EventType": "ChainedInvokeSucceeded",
-        "EventTimestamp": "2023-01-01T00:01:00Z",
+        "EventTimestamp": TIMESTAMP_2023_01_01_00_01,
         "ChainedInvokeSucceededDetails": {
             "Result": {"Payload": "invoke result", "Truncated": False}
         },
@@ -2536,7 +2545,7 @@ def test_event_with_invoke_succeeded_details():
     result_data = event_obj.to_dict()
     expected_data = {
         "EventType": "ChainedInvokeSucceeded",
-        "EventTimestamp": "2023-01-01T00:01:00Z",
+        "EventTimestamp": TIMESTAMP_2023_01_01_00_01,
         "EventId": 1,
         "ChainedInvokeSucceededDetails": {
             "Result": {"Payload": "invoke result", "Truncated": False}
@@ -2549,7 +2558,7 @@ def test_event_with_invoke_failed_details():
     """Test Event with ChainedInvokeFailedDetails."""
     data = {
         "EventType": "ChainedInvokeFailed",
-        "EventTimestamp": "2023-01-01T00:01:00Z",
+        "EventTimestamp": TIMESTAMP_2023_01_01_00_01,
         "ChainedInvokeFailedDetails": {
             "Error": {"Payload": {"ErrorMessage": "invoke failed"}, "Truncated": False}
         },
@@ -2565,7 +2574,7 @@ def test_event_with_invoke_failed_details():
     result_data = event_obj.to_dict()
     expected_data = {
         "EventType": "ChainedInvokeFailed",
-        "EventTimestamp": "2023-01-01T00:01:00Z",
+        "EventTimestamp": TIMESTAMP_2023_01_01_00_01,
         "EventId": 1,
         "ChainedInvokeFailedDetails": {
             "Error": {"Payload": {"ErrorMessage": "invoke failed"}, "Truncated": False}
@@ -2578,7 +2587,7 @@ def test_event_with_invoke_timed_out_details():
     """Test Event with ChainedInvokeTimedOutDetails."""
     data = {
         "EventType": "ChainedInvokeTimedOut",
-        "EventTimestamp": "2023-01-01T00:01:00Z",
+        "EventTimestamp": TIMESTAMP_2023_01_01_00_01,
         "ChainedInvokeTimedOutDetails": {
             "Error": {
                 "Payload": {"ErrorMessage": "invoke timed out"},
@@ -2598,7 +2607,7 @@ def test_event_with_invoke_timed_out_details():
     result_data = event_obj.to_dict()
     expected_data = {
         "EventType": "ChainedInvokeTimedOut",
-        "EventTimestamp": "2023-01-01T00:01:00Z",
+        "EventTimestamp": TIMESTAMP_2023_01_01_00_01,
         "EventId": 1,
         "ChainedInvokeTimedOutDetails": {
             "Error": {
@@ -2614,7 +2623,7 @@ def test_event_with_invoke_stopped_details():
     """Test Event with ChainedInvokeStoppedDetails."""
     data = {
         "EventType": "ChainedInvokeStopped",
-        "EventTimestamp": "2023-01-01T00:01:00Z",
+        "EventTimestamp": TIMESTAMP_2023_01_01_00_01,
         "ChainedInvokeStoppedDetails": {
             "Error": {"Payload": {"ErrorMessage": "invoke stopped"}, "Truncated": False}
         },
@@ -2631,7 +2640,7 @@ def test_event_with_invoke_stopped_details():
     result_data = event_obj.to_dict()
     expected_data = {
         "EventType": "ChainedInvokeStopped",
-        "EventTimestamp": "2023-01-01T00:01:00Z",
+        "EventTimestamp": TIMESTAMP_2023_01_01_00_01,
         "EventId": 1,
         "ChainedInvokeStoppedDetails": {
             "Error": {"Payload": {"ErrorMessage": "invoke stopped"}, "Truncated": False}
@@ -2644,7 +2653,7 @@ def test_event_with_callback_started_details():
     """Test Event with CallbackStartedDetails."""
     data = {
         "EventType": "CallbackStarted",
-        "EventTimestamp": "2023-01-01T00:01:00Z",
+        "EventTimestamp": TIMESTAMP_2023_01_01_00_01,
         "CallbackStartedDetails": {
             "CallbackId": "callback-123",
             "HeartbeatTimeout": 60,
@@ -2660,7 +2669,7 @@ def test_event_with_callback_started_details():
     result_data = event_obj.to_dict()
     expected_data = {
         "EventType": "CallbackStarted",
-        "EventTimestamp": "2023-01-01T00:01:00Z",
+        "EventTimestamp": TIMESTAMP_2023_01_01_00_01,
         "EventId": 1,
         "CallbackStartedDetails": {
             "CallbackId": "callback-123",
@@ -2675,7 +2684,7 @@ def test_event_with_callback_succeeded_details():
     """Test Event with CallbackSucceededDetails."""
     data = {
         "EventType": "CallbackSucceeded",
-        "EventTimestamp": "2023-01-01T00:01:00Z",
+        "EventTimestamp": TIMESTAMP_2023_01_01_00_01,
         "CallbackSucceededDetails": {
             "Result": {"Payload": "callback result", "Truncated": False}
         },
@@ -2689,7 +2698,7 @@ def test_event_with_callback_succeeded_details():
     result_data = event_obj.to_dict()
     expected_data = {
         "EventType": "CallbackSucceeded",
-        "EventTimestamp": "2023-01-01T00:01:00Z",
+        "EventTimestamp": TIMESTAMP_2023_01_01_00_01,
         "EventId": 1,
         "CallbackSucceededDetails": {
             "Result": {"Payload": "callback result", "Truncated": False}
@@ -2702,7 +2711,7 @@ def test_event_with_callback_failed_details():
     """Test Event with CallbackFailedDetails."""
     data = {
         "EventType": "CallbackFailed",
-        "EventTimestamp": "2023-01-01T00:01:00Z",
+        "EventTimestamp": TIMESTAMP_2023_01_01_00_01,
         "CallbackFailedDetails": {
             "Error": {
                 "Payload": {"ErrorMessage": "callback failed"},
@@ -2719,7 +2728,7 @@ def test_event_with_callback_failed_details():
     result_data = event_obj.to_dict()
     expected_data = {
         "EventType": "CallbackFailed",
-        "EventTimestamp": "2023-01-01T00:01:00Z",
+        "EventTimestamp": TIMESTAMP_2023_01_01_00_01,
         "EventId": 1,
         "CallbackFailedDetails": {
             "Error": {
@@ -2735,7 +2744,7 @@ def test_event_with_callback_timed_out_details():
     """Test Event with CallbackTimedOutDetails."""
     data = {
         "EventType": "CallbackTimedOut",
-        "EventTimestamp": "2023-01-01T00:01:00Z",
+        "EventTimestamp": TIMESTAMP_2023_01_01_00_01,
         "CallbackTimedOutDetails": {
             "Error": {
                 "Payload": {"ErrorMessage": "callback timed out"},
@@ -2755,7 +2764,7 @@ def test_event_with_callback_timed_out_details():
     result_data = event_obj.to_dict()
     expected_data = {
         "EventType": "CallbackTimedOut",
-        "EventTimestamp": "2023-01-01T00:01:00Z",
+        "EventTimestamp": TIMESTAMP_2023_01_01_00_01,
         "EventId": 1,
         "CallbackTimedOutDetails": {
             "Error": {
@@ -2812,8 +2821,8 @@ def test_list_durable_executions_by_function_request_all_optional_fields():
         function_name="my-function",
         qualifier=None,
         status_filter=None,
-        time_after=None,
-        time_before=None,
+        started_after=None,
+        started_before=None,
         marker=None,
         max_items=None,
         reverse_order=None,
@@ -2832,8 +2841,8 @@ def test_list_durable_executions_by_function_request_partial_fields():
         function_name="my-function",
         qualifier="$LATEST",
         status_filter=["RUNNING"],
-        time_after=None,
-        time_before="2023-01-02T00:00:00Z",
+        started_after=None,
+        started_before=TIMESTAMP_2023_01_02_00_00,
         marker=None,
         max_items=15,
         reverse_order=True,
@@ -2844,7 +2853,7 @@ def test_list_durable_executions_by_function_request_partial_fields():
         "FunctionName": "my-function",
         "Qualifier": "$LATEST",
         "StatusFilter": ["RUNNING"],
-        "TimeBefore": "2023-01-02T00:00:00Z",
+        "StartedBefore": TIMESTAMP_2023_01_02_00_00,
         "MaxItems": 15,
         "ReverseOrder": True,
     }
@@ -2890,8 +2899,8 @@ def test_list_durable_executions_by_function_request_with_durable_execution_name
         qualifier=None,
         durable_execution_name="specific-execution",
         status_filter=None,
-        time_after=None,
-        time_before=None,
+        started_after=None,
+        started_before=None,
         marker=None,
         max_items=None,
         reverse_order=None,

--- a/tests/runner_test.py
+++ b/tests/runner_test.py
@@ -339,7 +339,7 @@ def test_step_operation_wrong_type():
 def test_wait_operation_from_svc_operation():
     """Test WaitOperation creation from service operation."""
     scheduled_time = datetime.datetime.now(tz=datetime.UTC)
-    wait_details = WaitDetails(scheduled_timestamp=scheduled_time)
+    wait_details = WaitDetails(scheduled_end_timestamp=scheduled_time)
     svc_op = SvcOperation(
         operation_id="wait-id",
         operation_type=OperationType.WAIT,
@@ -351,7 +351,7 @@ def test_wait_operation_from_svc_operation():
 
     assert wait_op.operation_id == "wait-id"
     assert wait_op.operation_type is OperationType.WAIT
-    assert wait_op.scheduled_timestamp == scheduled_time
+    assert wait_op.scheduled_end_timestamp == scheduled_time
 
 
 def test_wait_operation_wrong_type():

--- a/tests/web/handlers_test.py
+++ b/tests/web/handlers_test.py
@@ -870,7 +870,7 @@ def test_stop_durable_execution_handler_success():
     handler = StopDurableExecutionHandler(executor)
 
     # Mock the executor response
-    mock_response = StopDurableExecutionResponse(end_timestamp="2023-01-01T00:01:00Z")
+    mock_response = StopDurableExecutionResponse(stop_timestamp="2023-01-01T00:01:00Z")
     executor.stop_execution.return_value = mock_response
 
     # Create request with proper stop data
@@ -900,7 +900,7 @@ def test_stop_durable_execution_handler_success():
 
     # Verify response
     assert response.status_code == 200
-    assert response.body == {"EndTimestamp": "2023-01-01T00:01:00Z"}
+    assert response.body == {"StopTimestamp": "2023-01-01T00:01:00Z"}
 
     # Verify executor was called with correct parameters
     executor.stop_execution.assert_called_once()


### PR DESCRIPTION
Updated all references to match main SDK's attribute name change.

*Issue #, if available:*
#42 

*Description of changes:*

- Updated all WaitDetails references: scheduled_timestamp → scheduled_end_timestamp
- Changed from str/float to datetime.datetime

<!-- PYTHON_LANGUAGE_SDK_BRANCH: main -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
