### PR TITLE
feat(testing-sdk): execution history event generation & pagination

### DIFF
--- a/tests/checkpoint/processors/base_test.py
+++ b/tests/checkpoint/processors/base_test.py
@@ -318,9 +318,11 @@ def test_create_invoke_details_no_options():
 
 def test_create_wait_details_with_current_operation():
     processor = MockProcessor()
-    scheduled_time = datetime.datetime.now(tz=datetime.UTC)
+    scheduled_end_timestamp = datetime.datetime.now(tz=datetime.UTC)
     current_op = Mock()
-    current_op.wait_details = WaitDetails(scheduled_end_timestamp=scheduled_time)
+    current_op.wait_details = WaitDetails(
+        scheduled_end_timestamp=scheduled_end_timestamp
+    )
 
     wait_options = WaitOptions(wait_seconds=30)
     update = OperationUpdate(
@@ -333,7 +335,7 @@ def test_create_wait_details_with_current_operation():
     result = processor.create_wait_details(update, current_op)
 
     assert isinstance(result, WaitDetails)
-    assert result.scheduled_end_timestamp == scheduled_time
+    assert result.scheduled_end_timestamp == scheduled_end_timestamp
 
 
 def test_create_wait_details_without_current_operation():

--- a/tests/event_factory_test.py
+++ b/tests/event_factory_test.py
@@ -1,0 +1,1284 @@
+"""Tests for Event factory methods.
+
+This module tests all the event creation factory methods in the Event class.
+"""
+
+from datetime import UTC, datetime
+
+import pytest
+from aws_durable_execution_sdk_python.lambda_service import (
+    ErrorObject,
+    OperationStatus,
+    OperationType,
+)
+
+from aws_durable_execution_sdk_python_testing.exceptions import (
+    InvalidParameterValueException,
+)
+from aws_durable_execution_sdk_python_testing.model import (
+    CheckpointDurableExecutionRequest,
+    ErrorResponse,
+    Event,
+    EventError,
+    EventInput,
+    EventResult,
+    Execution,
+    ExecutionStartedDetails,
+    LambdaContext,
+    StartDurableExecutionInput,
+)
+
+
+# Helper function to create mock operations
+def create_mock_operation(
+    operation_id: str = "op-1",
+    name: str = "test_op",
+    parent_id=None,
+    status: OperationStatus = OperationStatus.STARTED,
+):
+    from unittest.mock import Mock
+
+    op = Mock()
+    op.operation_id = operation_id
+    op.name = name
+    op.parent_id = parent_id
+    op.status = status
+    return op
+
+
+# region execution-tests
+def test_create_execution_started():
+    operation = create_mock_operation(
+        "op-1", "test_execution", status=OperationStatus.STARTED
+    )
+    event_input = EventInput(payload='{"test": "data"}', truncated=False)
+    event = Event.create_execution_event(
+        operation=operation,
+        event_timestamp=datetime.fromisoformat("2024-01-01T12:00:00Z"),
+        event_id=1,
+        operation_status=OperationStatus.STARTED,
+        event_input=event_input,
+        execution_timeout=300,
+    )
+
+    assert event.event_type == "ExecutionStarted"
+    assert event.operation_id == "op-1"
+    assert event.name == "test_execution"
+    assert event.execution_started_details.input.payload == '{"test": "data"}'
+    assert event.execution_started_details.execution_timeout == 300
+
+
+def test_create_execution_succeeded():
+    operation = create_mock_operation("op-1", status=OperationStatus.SUCCEEDED)
+    event_result = EventResult(payload='{"result": "success"}', truncated=False)
+    event = Event.create_execution_event(
+        operation=operation,
+        event_timestamp=datetime.fromisoformat("2024-01-01T12:00:00Z"),
+        event_id=2,
+        event_result=event_result,
+    )
+
+    assert event.event_type == "ExecutionSucceeded"
+    assert event.execution_succeeded_details.result.payload == '{"result": "success"}'
+
+
+def test_create_execution_failed():
+    operation = create_mock_operation("op-1", status=OperationStatus.FAILED)
+    error_obj = ErrorObject.from_message("Execution failed")
+    event_error = EventError(payload=error_obj, truncated=False)
+    event = Event.create_execution_event(
+        operation=operation,
+        event_timestamp=datetime.fromisoformat("2024-01-01T12:00:00Z"),
+        event_id=3,
+        event_error=event_error,
+    )
+
+    assert event.event_type == "ExecutionFailed"
+    assert event.execution_failed_details.error.payload.message == "Execution failed"
+
+
+def test_create_execution_timed_out():
+    operation = create_mock_operation("op-1", status=OperationStatus.TIMED_OUT)
+    error_obj = ErrorObject.from_message("Execution timed out")
+    event_error = EventError(payload=error_obj, truncated=False)
+    event = Event.create_execution_event(
+        operation=operation,
+        event_timestamp=datetime.fromisoformat("2024-01-01T12:00:00Z"),
+        event_id=4,
+        event_error=event_error,
+    )
+
+    assert event.event_type == "ExecutionTimedOut"
+    assert (
+        event.execution_timed_out_details.error.payload.message == "Execution timed out"
+    )
+
+
+def test_create_execution_stopped():
+    operation = create_mock_operation("op-1", status=OperationStatus.STOPPED)
+    error_obj = ErrorObject.from_message("Execution stopped")
+    event_error = EventError(payload=error_obj, truncated=False)
+    event = Event.create_execution_event(
+        operation=operation,
+        event_timestamp=datetime.fromisoformat("2024-01-01T12:00:00Z"),
+        event_id=5,
+        event_error=event_error,
+    )
+
+    assert event.event_type == "ExecutionStopped"
+    assert event.execution_stopped_details.error.payload.message == "Execution stopped"
+
+
+def test_create_execution_invalid_status():
+    operation = create_mock_operation("op-1", status=OperationStatus.CANCELLED)
+    with pytest.raises(
+        InvalidParameterValueException,
+        match="Operation status .* is not valid for execution operations",
+    ):
+        Event.create_execution_event(
+            operation=operation,
+            event_timestamp=datetime.fromisoformat("2024-01-01T12:00:00Z"),
+            event_id=1,
+            operation_status=OperationStatus.CANCELLED,
+        )
+
+
+# endregion execution-tests
+
+
+# region context-tests
+def test_create_context_started():
+    operation = create_mock_operation(
+        "ctx-1", "test_context", status=OperationStatus.STARTED
+    )
+    event = Event.create_context_event(
+        operation=operation,
+        event_timestamp=datetime.fromisoformat("2024-01-01T12:00:00Z"),
+        event_id=1,
+        operation_status=OperationStatus.STARTED,
+    )
+
+    assert event.event_type == "ContextStarted"
+    assert event.operation_id == "ctx-1"
+    assert event.name == "test_context"
+    assert event.context_started_details is not None
+
+
+def test_create_context_succeeded():
+    operation = create_mock_operation("ctx-1", status=OperationStatus.SUCCEEDED)
+    operation.context_details = type(
+        "MockDetails", (), {"result": '{"context": "result"}', "error": None}
+    )()
+    event = Event.create_context_event(
+        operation=operation,
+        event_timestamp=datetime.fromisoformat("2024-01-01T12:00:00Z"),
+        event_id=2,
+        include_execution_data=True,
+    )
+
+    assert event.event_type == "ContextSucceeded"
+    assert event.context_succeeded_details.result.payload == '{"context": "result"}'
+
+
+def test_create_context_failed():
+    operation = create_mock_operation("ctx-1", status=OperationStatus.FAILED)
+    error_obj = ErrorObject.from_message("Context failed")
+    operation.context_details = type(
+        "MockDetails", (), {"result": None, "error": error_obj}
+    )()
+    event = Event.create_context_event(
+        operation=operation,
+        event_timestamp=datetime.fromisoformat("2024-01-01T12:00:00Z"),
+        event_id=3,
+    )
+
+    assert event.event_type == "ContextFailed"
+    assert event.context_failed_details.error.payload.message == "Context failed"
+
+
+def test_create_context_invalid_status():
+    operation = create_mock_operation("ctx-1", status=OperationStatus.TIMED_OUT)
+    with pytest.raises(
+        InvalidParameterValueException,
+        match="Operation status .* is not valid for context operations",
+    ):
+        Event.create_context_event(
+            operation=operation,
+            event_timestamp=datetime.fromisoformat("2024-01-01T12:00:00Z"),
+            event_id=1,
+            operation_status=OperationStatus.TIMED_OUT,
+        )
+
+
+# endregion context-tests
+
+
+# region wait-tests
+def test_create_wait_started():
+    operation = create_mock_operation("wait-1", status=OperationStatus.STARTED)
+    operation.start_timestamp = datetime.fromisoformat("2024-01-01T12:00:00Z")
+    operation.wait_details = type(
+        "MockDetails",
+        (),
+        {"scheduled_end_timestamp": datetime.fromisoformat("2024-01-01T12:05:00Z")},
+    )()
+    event = Event.create_wait_event(
+        operation=operation,
+        event_timestamp=datetime.fromisoformat("2024-01-01T12:00:00Z"),
+        event_id=1,
+        operation_status=OperationStatus.STARTED,
+    )
+
+    assert event.event_type == "WaitStarted"
+    assert event.wait_started_details.duration == 300
+    assert event.wait_started_details.scheduled_end_timestamp == datetime.fromisoformat(
+        "2024-01-01T12:05:00Z"
+    )
+
+
+def test_create_wait_succeeded():
+    operation = create_mock_operation("wait-1", status=OperationStatus.SUCCEEDED)
+    operation.start_timestamp = datetime.fromisoformat("2024-01-01T12:00:00Z")
+    operation.wait_details = type(
+        "MockDetails",
+        (),
+        {"scheduled_end_timestamp": datetime.fromisoformat("2024-01-01T12:05:00Z")},
+    )()
+    event = Event.create_wait_event(
+        operation=operation,
+        event_timestamp="2024-01-01T12:05:00Z",
+        event_id=2,
+    )
+
+    assert event.event_type == "WaitSucceeded"
+    assert event.wait_succeeded_details.duration == 300
+
+
+def test_create_wait_cancelled():
+    operation = create_mock_operation("wait-1", status=OperationStatus.CANCELLED)
+    operation.wait_details = None
+    event = Event.create_wait_event(
+        operation=operation,
+        event_timestamp="2024-01-01T12:03:00Z",
+        event_id=3,
+    )
+
+    assert event.event_type == "WaitCancelled"
+    assert event.wait_cancelled_details is not None
+
+
+def test_create_wait_invalid_status():
+    operation = create_mock_operation("wait-1", status=OperationStatus.FAILED)
+    operation.wait_details.scheduled_end_timestamp = operation.start_timestamp = (
+        datetime.fromisoformat("2024-01-01T12:00:00Z")
+    )
+    with pytest.raises(
+        InvalidParameterValueException,
+        match="Operation status .* is not valid for wait operations",
+    ):
+        Event.create_wait_event(
+            operation=operation,
+            event_timestamp=datetime.fromisoformat("2024-01-01T12:00:00Z"),
+            event_id=1,
+            operation_status=OperationStatus.FAILED,
+        )
+
+
+# endregion wait-tests
+
+
+# region step-tests
+def test_create_step_started():
+    operation = create_mock_operation(
+        "step-1", "test_step", status=OperationStatus.STARTED
+    )
+    event = Event.create_step_event(
+        operation=operation,
+        event_timestamp=datetime.fromisoformat("2024-01-01T12:00:00Z"),
+        event_id=1,
+        operation_status=OperationStatus.STARTED,
+    )
+
+    assert event.event_type == "StepStarted"
+    assert event.operation_id == "step-1"
+    assert event.name == "test_step"
+    assert event.step_started_details is not None
+
+
+def test_create_step_succeeded():
+    operation = create_mock_operation("step-1", status=OperationStatus.SUCCEEDED)
+    operation.step_details = type(
+        "MockDetails", (), {"result": '{"step": "result"}', "error": None}
+    )()
+    event = Event.create_step_event(
+        operation=operation,
+        event_timestamp=datetime.fromisoformat("2024-01-01T12:00:00Z"),
+        event_id=2,
+        include_execution_data=True,
+    )
+
+    assert event.event_type == "StepSucceeded"
+    assert event.step_succeeded_details.result.payload == '{"step": "result"}'
+
+
+def test_create_step_failed():
+    operation = create_mock_operation("step-1", status=OperationStatus.FAILED)
+    error_obj = ErrorObject.from_message("Step failed")
+    operation.step_details = type(
+        "MockDetails", (), {"result": None, "error": error_obj}
+    )()
+    event = Event.create_step_event(
+        operation=operation,
+        event_timestamp=datetime.fromisoformat("2024-01-01T12:00:00Z"),
+        event_id=3,
+    )
+
+    assert event.event_type == "StepFailed"
+    assert event.step_failed_details.error.payload.message == "Step failed"
+
+
+def test_create_step_invalid_status():
+    operation = create_mock_operation("step-1", status=OperationStatus.TIMED_OUT)
+    with pytest.raises(
+        InvalidParameterValueException,
+        match="Operation status .* is not valid for step operations",
+    ):
+        Event.create_step_event(
+            operation=operation,
+            event_timestamp=datetime.fromisoformat("2024-01-01T12:00:00Z"),
+            event_id=1,
+            operation_status=OperationStatus.TIMED_OUT,
+        )
+
+
+# endregion step-tests
+
+
+# region chained_invoke
+def test_create_chained_invoke_started():
+    operation = create_mock_operation(
+        "invoke-1", "test_invoke", status=OperationStatus.STARTED
+    )
+    event = Event.create_chained_invoke_event(
+        operation=operation,
+        event_timestamp=datetime.fromisoformat("2024-01-01T12:00:00Z"),
+        event_id=1,
+        operation_status=OperationStatus.STARTED,
+    )
+
+    assert event.event_type == "ChainedInvokeStarted"
+    assert event.operation_id == "invoke-1"
+    assert event.name == "test_invoke"
+    assert event.chained_invoke_started_details is not None
+
+
+# endregion callback
+
+
+# endregion helpers-test
+
+
+def test_create_chained_invoke_succeeded():
+    operation = create_mock_operation("invoke-1", status=OperationStatus.SUCCEEDED)
+    operation.chained_invoke_details = type(
+        "MockDetails", (), {"result": '{"invoke": "result"}', "error": None}
+    )()
+    event = Event.create_chained_invoke_event(
+        operation=operation,
+        event_timestamp=datetime.fromisoformat("2024-01-01T12:00:00Z"),
+        event_id=2,
+        include_execution_data=True,
+    )
+
+    assert event.event_type == "ChainedInvokeSucceeded"
+    assert (
+        event.chained_invoke_succeeded_details.result.payload == '{"invoke": "result"}'
+    )
+
+
+def test_create_chained_invoke_failed():
+    operation = create_mock_operation("invoke-1", status=OperationStatus.FAILED)
+    error_obj = ErrorObject.from_message("Invoke failed")
+    operation.chained_invoke_details = type(
+        "MockDetails", (), {"result": None, "error": error_obj}
+    )()
+    event = Event.create_chained_invoke_event(
+        operation=operation,
+        event_timestamp=datetime.fromisoformat("2024-01-01T12:00:00Z"),
+        event_id=3,
+    )
+
+    assert event.event_type == "ChainedInvokeFailed"
+    assert event.chained_invoke_failed_details.error.payload.message == "Invoke failed"
+
+
+def test_create_chained_invoke_timed_out():
+    operation = create_mock_operation("invoke-1", status=OperationStatus.TIMED_OUT)
+    error_obj = ErrorObject.from_message("Invoke timed out")
+    operation.chained_invoke_details = type(
+        "MockDetails", (), {"result": None, "error": error_obj}
+    )()
+    event = Event.create_chained_invoke_event(
+        operation=operation,
+        event_timestamp=datetime.fromisoformat("2024-01-01T12:00:00Z"),
+        event_id=4,
+    )
+
+    assert event.event_type == "ChainedInvokeTimedOut"
+    assert (
+        event.chained_invoke_timed_out_details.error.payload.message
+        == "Invoke timed out"
+    )
+
+
+def test_create_chained_invoke_stopped():
+    operation = create_mock_operation("invoke-1", status=OperationStatus.STOPPED)
+    error_obj = ErrorObject.from_message("Invoke stopped")
+    operation.chained_invoke_details = type(
+        "MockDetails", (), {"result": None, "error": error_obj}
+    )()
+    event = Event.create_chained_invoke_event(
+        operation=operation,
+        event_timestamp=datetime.fromisoformat("2024-01-01T12:00:00Z"),
+        event_id=5,
+    )
+
+    assert event.event_type == "ChainedInvokeStopped"
+    assert (
+        event.chained_invoke_stopped_details.error.payload.message == "Invoke stopped"
+    )
+
+
+def test_create_chained_invoke_invalid_status():
+    operation = create_mock_operation("invoke-1", status=OperationStatus.CANCELLED)
+    with pytest.raises(
+        InvalidParameterValueException,
+        match="Operation status .* is not valid for chained invoke operations",
+    ):
+        Event.create_chained_invoke_event(
+            operation=operation,
+            event_timestamp=datetime.fromisoformat("2024-01-01T12:00:00Z"),
+            event_id=1,
+            operation_status=OperationStatus.CANCELLED,
+        )
+
+
+# endregion chained_invoke
+
+
+# region callback-tests
+def test_create_callback_started():
+    operation = create_mock_operation(
+        "callback-1", "test_callback", status=OperationStatus.STARTED
+    )
+    operation.callback_details = type(
+        "MockDetails", (), {"callback_id": "cb-123", "result": None, "error": None}
+    )()
+    event = Event.create_callback_event(
+        operation=operation,
+        event_timestamp=datetime.fromisoformat("2024-01-01T12:00:00Z"),
+        event_id=1,
+        operation_status=OperationStatus.STARTED,
+    )
+
+    assert event.event_type == "CallbackStarted"
+    assert event.operation_id == "callback-1"
+    assert event.name == "test_callback"
+    assert event.callback_started_details.callback_id == "cb-123"
+
+
+def test_create_callback_succeeded():
+    operation = create_mock_operation("callback-1", status=OperationStatus.SUCCEEDED)
+    operation.callback_details = type(
+        "MockDetails",
+        (),
+        {"callback_id": None, "result": '{"callback": "result"}', "error": None},
+    )()
+    event = Event.create_callback_event(
+        operation=operation,
+        event_timestamp=datetime.fromisoformat("2024-01-01T12:00:00Z"),
+        event_id=2,
+        include_execution_data=True,
+    )
+
+    assert event.event_type == "CallbackSucceeded"
+    assert event.callback_succeeded_details.result.payload == '{"callback": "result"}'
+
+
+def test_create_callback_failed():
+    operation = create_mock_operation("callback-1", status=OperationStatus.FAILED)
+    error_obj = ErrorObject.from_message("Callback failed")
+    operation.callback_details = type(
+        "MockDetails", (), {"callback_id": None, "result": None, "error": error_obj}
+    )()
+    event = Event.create_callback_event(
+        operation=operation,
+        event_timestamp=datetime.fromisoformat("2024-01-01T12:00:00Z"),
+        event_id=3,
+    )
+
+    assert event.event_type == "CallbackFailed"
+    assert event.callback_failed_details.error.payload.message == "Callback failed"
+
+
+def test_create_callback_timed_out():
+    operation = create_mock_operation("callback-1", status=OperationStatus.TIMED_OUT)
+    error_obj = ErrorObject.from_message("Callback timed out")
+    operation.callback_details = type(
+        "MockDetails", (), {"callback_id": None, "result": None, "error": error_obj}
+    )()
+    event = Event.create_callback_event(
+        operation=operation,
+        event_timestamp=datetime.fromisoformat("2024-01-01T12:00:00Z"),
+        event_id=4,
+    )
+
+    assert event.event_type == "CallbackTimedOut"
+    assert (
+        event.callback_timed_out_details.error.payload.message == "Callback timed out"
+    )
+
+
+def test_create_callback_invalid_status():
+    operation = create_mock_operation("callback-1", status=OperationStatus.STOPPED)
+    with pytest.raises(
+        InvalidParameterValueException,
+        match="Operation status .* is not valid for callback operations",
+    ):
+        Event.create_callback_event(
+            operation=operation,
+            event_timestamp=datetime.fromisoformat("2024-01-01T12:00:00Z"),
+            event_id=1,
+            operation_status=OperationStatus.STOPPED,
+        )
+
+
+# endregion callback-tests
+
+
+# region model-tests
+def test_lambda_context():
+    context = LambdaContext(aws_request_id="test-123")
+    assert context.aws_request_id == "test-123"
+    assert context.get_remaining_time_in_millis() == 900000
+    context.log("test message")  # Should not raise
+
+
+def test_start_durable_execution_input_missing_field():
+    with pytest.raises(
+        InvalidParameterValueException, match="Missing required field: AccountId"
+    ):
+        StartDurableExecutionInput.from_dict({})
+
+
+def test_start_durable_execution_input_to_dict_with_optionals():
+    input_obj = StartDurableExecutionInput(
+        account_id="123456789",
+        function_name="test-func",
+        function_qualifier="$LATEST",
+        execution_name="test-exec",
+        execution_timeout_seconds=300,
+        execution_retention_period_days=7,
+        invocation_id="inv-123",
+        trace_fields={"key": "value"},
+        tenant_id="tenant-123",
+        input='{"test": "data"}',
+    )
+    result = input_obj.to_dict()
+    assert result["InvocationId"] == "inv-123"
+    assert result["TraceFields"] == {"key": "value"}
+    assert result["TenantId"] == "tenant-123"
+    assert result["Input"] == '{"test": "data"}'
+
+
+def test_execution_from_dict_empty_function_arn():
+    data = {
+        "DurableExecutionArn": "arn:aws:lambda:us-east-1:123456789:function:test",
+        "DurableExecutionName": "test-exec",
+        "Status": "SUCCEEDED",
+        "StartTimestamp": 1640995200.0,
+    }
+    execution = Execution.from_dict(data)
+    assert execution.function_arn == ""
+
+
+def test_execution_to_dict_with_function_arn():
+    execution = Execution(
+        durable_execution_arn="arn:aws:lambda:us-east-1:123456789:function:test",
+        durable_execution_name="test-exec",
+        function_arn="arn:aws:lambda:us-east-1:123456789:function:test",
+        status="SUCCEEDED",
+        start_timestamp=1640995200.0,
+    )
+    result = execution.to_dict()
+    assert "FunctionArn" in result
+
+
+def test_event_input_from_details():
+    from aws_durable_execution_sdk_python.lambda_service import ExecutionDetails
+
+    details = ExecutionDetails(input_payload='{"test": "data"}')
+    event_input = EventInput.from_details(details, include=True)
+    assert event_input.payload == '{"test": "data"}'
+    assert not event_input.truncated
+
+    event_input_truncated = EventInput.from_details(details, include=False)
+    assert event_input_truncated.payload is None
+    assert event_input_truncated.truncated
+
+
+def test_event_result_from_details():
+    from aws_durable_execution_sdk_python.lambda_service import StepDetails
+
+    details = StepDetails(result='{"result": "success"}')
+    event_result = EventResult.from_details(details, include=True)
+    assert event_result.payload == '{"result": "success"}'
+    assert not event_result.truncated
+
+
+def test_event_error_from_details():
+    from aws_durable_execution_sdk_python.lambda_service import StepDetails
+
+    error_obj = ErrorObject.from_message("Test error")
+    details = StepDetails(error=error_obj)
+    event_error = EventError.from_details(details)
+    assert event_error.payload.message == "Test error"
+
+
+def test_event_from_dict_with_all_details():
+    data = {
+        "EventType": "ExecutionStarted",
+        "EventTimestamp": datetime.fromisoformat("2024-01-01T12:00:00Z"),
+        "EventId": 1,
+        "Id": "op-1",
+        "Name": "test",
+        "ParentId": "parent-1",
+        "SubType": "test-subtype",
+        "ExecutionStartedDetails": {
+            "Input": {"Payload": '{"test": "data"}', "Truncated": False},
+            "ExecutionTimeout": 300,
+        },
+    }
+    event = Event.from_dict(data)
+    assert event.sub_type == "test-subtype"
+    assert event.parent_id == "parent-1"
+
+
+def test_event_to_dict_with_all_details():
+    event = Event(
+        event_type="ExecutionStarted",
+        event_timestamp=datetime.fromisoformat("2024-01-01T12:00:00Z"),
+        event_id=1,
+        operation_id="op-1",
+        name="test",
+        parent_id="parent-1",
+        sub_type="test-subtype",
+        execution_started_details=ExecutionStartedDetails(
+            input=EventInput(payload='{"test": "data"}', truncated=False),
+            execution_timeout=300,
+        ),
+    )
+    result = event.to_dict()
+    assert result["SubType"] == "test-subtype"
+    assert result["ParentId"] == "parent-1"
+    assert result["ExecutionStartedDetails"]["ExecutionTimeout"] == 300
+
+
+def test_error_response_from_dict_nested():
+    data = {
+        "error": {
+            "type": "ValidationError",
+            "message": "Invalid input",
+            "code": "400",
+            "requestId": "req-123",
+        }
+    }
+    error_response = ErrorResponse.from_dict(data)
+    assert error_response.error_type == "ValidationError"
+    assert error_response.error_message == "Invalid input"
+    assert error_response.error_code == "400"
+    assert error_response.request_id == "req-123"
+
+
+def test_error_response_from_dict_flat():
+    data = {"type": "ValidationError", "message": "Invalid input"}
+    error_response = ErrorResponse.from_dict(data)
+    assert error_response.error_type == "ValidationError"
+    assert error_response.error_message == "Invalid input"
+
+
+def test_checkpoint_durable_execution_request_from_dict():
+    token: str = "token-123"
+    data = {
+        "CheckpointToken": token,
+        "Updates": [
+            {"Id": "op-1", "Type": "STEP", "Action": "START", "SubType": "Step"}
+        ],
+    }
+    request = CheckpointDurableExecutionRequest.from_dict(data, "arn:test")
+    assert request.checkpoint_token == token
+    assert len(request.updates) == 1
+    assert request.updates[0].operation_id == "op-1"
+
+
+# endregion model-tests
+
+
+# region from_operation_started_tests
+class TestFromOperationStarted:
+    """Tests for Event.from_operation_started method."""
+
+    def test_from_operation_started_execution(self):
+        """Test converting execution operation to started event."""
+        from datetime import UTC, datetime
+        from unittest.mock import Mock
+
+        operation = Mock()
+        operation.operation_id = "exec-123"
+        operation.name = "test_execution"
+        operation.parent_id = "parent-123"
+        operation.operation_type = OperationType.EXECUTION
+        operation.start_timestamp = datetime(2024, 1, 1, 12, 0, 0, tzinfo=UTC)
+
+        execution_details = Mock()
+        execution_details.input_payload = '{"test": "data"}'
+        operation.execution_details = execution_details
+
+        event = Event.from_operation_started(
+            operation, event_id=1, include_execution_data=True
+        )
+
+        assert event.event_type == "ExecutionStarted"
+        assert event.operation_id == "exec-123"
+        assert event.name == "test_execution"
+        assert event.parent_id == "parent-123"
+        assert event.execution_started_details.input.payload == '{"test": "data"}'
+        assert not event.execution_started_details.input.truncated
+
+    def test_from_operation_started_execution_no_data(self):
+        """Test execution operation with include_execution_data=False."""
+        from datetime import UTC, datetime
+        from unittest.mock import Mock
+
+        operation = Mock()
+        operation.operation_id = "exec-123"
+        operation.name = "test_execution"
+        operation.parent_id = "parent-123"
+        operation.operation_type = OperationType.EXECUTION
+        operation.start_timestamp = datetime(2024, 1, 1, 12, 0, 0, tzinfo=UTC)
+
+        execution_details = Mock()
+        execution_details.input_payload = '{"test": "data"}'
+        operation.execution_details = execution_details
+
+        event = Event.from_operation_started(
+            operation, event_id=1, include_execution_data=False
+        )
+
+        assert event.event_type == "ExecutionStarted"
+        assert event.execution_started_details.input.payload is None
+        assert event.execution_started_details.input.truncated
+
+    def test_from_operation_started_step(self):
+        """Test converting step operation to started event."""
+        from datetime import UTC, datetime
+        from unittest.mock import Mock
+
+        operation = Mock()
+        operation.operation_id = "step-123"
+        operation.name = "test_step"
+        operation.parent_id = "parent-123"
+        operation.operation_type = OperationType.STEP
+        operation.start_timestamp = datetime(2024, 1, 1, 12, 0, 0, tzinfo=UTC)
+
+        event = Event.from_operation_started(operation, event_id=2)
+
+        assert event.event_type == "StepStarted"
+        assert event.operation_id == "step-123"
+        assert event.name == "test_step"
+        assert event.parent_id == "parent-123"
+        assert event.step_started_details is not None
+
+    def test_from_operation_started_wait(self):
+        """Test converting wait operation to started event."""
+        from datetime import UTC, datetime
+        from unittest.mock import Mock
+
+        operation = Mock()
+        operation.operation_id = "wait-123"
+        operation.name = "test_wait"
+        operation.parent_id = "parent-123"
+        operation.operation_type = OperationType.WAIT
+        operation.start_timestamp = datetime(2024, 1, 1, 12, 0, 0, tzinfo=UTC)
+
+        wait_details = Mock()
+        wait_details.scheduled_end_timestamp = datetime(
+            2024, 1, 1, 12, 5, 0, tzinfo=UTC
+        )
+        operation.wait_details = wait_details
+
+        event = Event.from_operation_started(operation, event_id=3)
+
+        assert event.event_type == "WaitStarted"
+        assert event.operation_id == "wait-123"
+        assert event.name == "test_wait"
+        assert event.parent_id == "parent-123"
+        assert event.wait_started_details.duration == 300
+        assert (
+            event.wait_started_details.scheduled_end_timestamp
+            == datetime.fromisoformat("2024-01-01T12:05:00+00:00")
+        )
+
+    def test_from_operation_started_callback(self):
+        """Test converting callback operation to started event."""
+        from datetime import UTC, datetime
+        from unittest.mock import Mock
+
+        operation = Mock()
+        operation.operation_id = "callback-123"
+        operation.name = "test_callback"
+        operation.parent_id = "parent-123"
+        operation.operation_type = OperationType.CALLBACK
+        operation.start_timestamp = datetime(2024, 1, 1, 12, 0, 0, tzinfo=UTC)
+
+        callback_details = Mock()
+        callback_details.callback_id = "cb-456"
+        operation.callback_details = callback_details
+
+        event = Event.from_operation_started(operation, event_id=4)
+
+        assert event.event_type == "CallbackStarted"
+        assert event.operation_id == "callback-123"
+        assert event.name == "test_callback"
+        assert event.parent_id == "parent-123"
+        assert event.callback_started_details.callback_id == "cb-456"
+
+    def test_from_operation_started_chained_invoke(self):
+        """Test converting chained invoke operation to started event."""
+        from datetime import UTC, datetime
+        from unittest.mock import Mock
+
+        operation = Mock()
+        operation.operation_id = "invoke-123"
+        operation.name = "test_invoke"
+        operation.parent_id = "parent-123"
+        operation.operation_type = OperationType.CHAINED_INVOKE
+        operation.start_timestamp = datetime(2024, 1, 1, 12, 0, 0, tzinfo=UTC)
+
+        event = Event.from_operation_started(operation, event_id=5)
+
+        assert event.event_type == "ChainedInvokeStarted"
+        assert event.operation_id == "invoke-123"
+        assert event.name == "test_invoke"
+        assert event.parent_id == "parent-123"
+        assert event.chained_invoke_started_details is not None
+
+    def test_from_operation_started_context(self):
+        """Test converting context operation to started event."""
+        from datetime import UTC, datetime
+        from unittest.mock import Mock
+
+        operation = Mock()
+        operation.operation_id = "context-123"
+        operation.name = "test_context"
+        operation.parent_id = "parent-123"
+        operation.operation_type = OperationType.CONTEXT
+        operation.start_timestamp = datetime(2024, 1, 1, 12, 0, 0, tzinfo=UTC)
+
+        event = Event.from_operation_started(operation, event_id=6)
+
+        assert event.event_type == "ContextStarted"
+        assert event.operation_id == "context-123"
+        assert event.name == "test_context"
+        assert event.parent_id == "parent-123"
+        assert event.context_started_details is not None
+
+    def test_from_operation_started_no_timestamp(self):
+        """Test error when operation has no start timestamp."""
+        from unittest.mock import Mock
+
+        operation = Mock()
+        operation.start_timestamp = None
+
+        with pytest.raises(
+            InvalidParameterValueException,
+            match="Operation start timestamp cannot be None",
+        ):
+            Event.from_operation_started(operation, event_id=1)
+
+    def test_from_operation_started_unknown_type(self):
+        """Test error with unknown operation type."""
+        from datetime import UTC, datetime
+        from unittest.mock import Mock
+
+        operation = Mock()
+        operation.operation_type = "UNKNOWN_TYPE"
+        operation.start_timestamp = datetime(2024, 1, 1, 12, 0, 0, tzinfo=UTC)
+
+        with pytest.raises(
+            InvalidParameterValueException, match="Unknown operation type: UNKNOWN_TYPE"
+        ):
+            Event.from_operation_started(operation, event_id=1)
+
+
+# endregion from_operation_started_tests
+
+
+# region from_operation_finished_tests
+class TestFromOperationFinished:
+    """Tests for Event.from_operation_finished method."""
+
+    def test_from_operation_finished_execution_succeeded(self):
+        """Test converting succeeded execution operation to finished event."""
+        from datetime import UTC, datetime
+        from unittest.mock import Mock
+
+        operation = Mock()
+        operation.operation_id = "exec-123"
+        operation.name = "test_execution"
+        operation.parent_id = "parent-123"
+        operation.operation_type = OperationType.EXECUTION
+        operation.status = OperationStatus.SUCCEEDED
+        operation.end_timestamp = datetime(2024, 1, 1, 12, 5, 0, tzinfo=UTC)
+
+        event = Event.from_operation_finished(operation, event_id=1)
+
+        assert event.event_type == "ExecutionSucceeded"
+        assert event.operation_id == "exec-123"
+        assert event.name == "test_execution"
+        assert event.parent_id == "parent-123"
+
+    def test_from_operation_finished_execution_failed(self):
+        """Test converting failed execution operation to finished event."""
+        from datetime import UTC, datetime
+        from unittest.mock import Mock
+
+        operation = Mock()
+        operation.operation_id = "exec-123"
+        operation.name = "test_execution"
+        operation.parent_id = "parent-123"
+        operation.operation_type = OperationType.EXECUTION
+        operation.status = OperationStatus.FAILED
+        operation.end_timestamp = datetime(2024, 1, 1, 12, 5, 0, tzinfo=UTC)
+
+        event = Event.from_operation_finished(operation, event_id=1)
+
+        assert event.event_type == "ExecutionFailed"
+        assert event.operation_id == "exec-123"
+
+    def test_from_operation_finished_step_with_result(self):
+        """Test converting succeeded step operation with result."""
+        from datetime import UTC, datetime
+        from unittest.mock import Mock
+
+        operation = Mock()
+        operation.operation_id = "step-123"
+        operation.name = "test_step"
+        operation.parent_id = "parent-123"
+        operation.operation_type = OperationType.STEP
+        operation.status = OperationStatus.SUCCEEDED
+        operation.end_timestamp = datetime(2024, 1, 1, 12, 5, 0, tzinfo=UTC)
+
+        step_details = Mock()
+        step_details.result = '{"result": "success"}'
+        step_details.error = None
+        operation.step_details = step_details
+
+        event = Event.from_operation_finished(
+            operation, event_id=2, include_execution_data=True
+        )
+
+        assert event.event_type == "StepSucceeded"
+        assert event.operation_id == "step-123"
+        assert event.step_succeeded_details.result.payload == '{"result": "success"}'
+
+    def test_from_operation_finished_step_with_error(self):
+        """Test converting failed step operation with error."""
+        from datetime import UTC, datetime
+        from unittest.mock import Mock
+
+        operation = Mock()
+        operation.operation_id = "step-123"
+        operation.name = "test_step"
+        operation.parent_id = "parent-123"
+        operation.operation_type = OperationType.STEP
+        operation.status = OperationStatus.FAILED
+        operation.end_timestamp = datetime(2024, 1, 1, 12, 5, 0, tzinfo=UTC)
+
+        step_details = Mock()
+        step_details.result = None
+        step_details.error = ErrorObject.from_message("Step failed")
+        operation.step_details = step_details
+
+        event = Event.from_operation_finished(operation, event_id=2)
+
+        assert event.event_type == "StepFailed"
+        assert event.step_failed_details.error.payload.message == "Step failed"
+
+    def test_from_operation_finished_wait_succeeded(self):
+        """Test converting succeeded wait operation."""
+        from datetime import UTC, datetime
+        from unittest.mock import Mock
+
+        operation = Mock()
+        operation.operation_id = "wait-123"
+        operation.name = "test_wait"
+        operation.parent_id = "parent-123"
+        operation.operation_type = OperationType.WAIT
+        operation.status = OperationStatus.SUCCEEDED
+        operation.start_timestamp = datetime(2024, 1, 1, 12, 0, 0, tzinfo=UTC)
+        operation.end_timestamp = datetime(2024, 1, 1, 12, 5, 0, tzinfo=UTC)
+
+        wait_details = Mock()
+        wait_details.scheduled_end_timestamp = datetime(
+            2024, 1, 1, 12, 5, 0, tzinfo=UTC
+        )
+        operation.wait_details = wait_details
+
+        event = Event.from_operation_finished(operation, event_id=3)
+
+        assert event.event_type == "WaitSucceeded"
+        assert event.wait_succeeded_details.duration == 300
+
+    def test_from_operation_finished_wait_cancelled(self):
+        """Test converting cancelled wait operation."""
+        from datetime import UTC, datetime
+        from unittest.mock import Mock
+
+        operation = Mock()
+        operation.operation_id = "wait-123"
+        operation.name = "test_wait"
+        operation.parent_id = "parent-123"
+        operation.operation_type = OperationType.WAIT
+        operation.status = OperationStatus.CANCELLED
+        operation.end_timestamp = datetime(2024, 1, 1, 12, 3, 0, tzinfo=UTC)
+        operation.wait_details = None
+
+        event = Event.from_operation_finished(operation, event_id=3)
+
+        assert event.event_type == "WaitCancelled"
+        assert event.wait_cancelled_details is not None
+
+    def test_from_operation_finished_callback_succeeded(self):
+        """Test converting succeeded callback operation."""
+        from datetime import UTC, datetime
+        from unittest.mock import Mock
+
+        operation = Mock()
+        operation.operation_id = "callback-123"
+        operation.name = "test_callback"
+        operation.parent_id = "parent-123"
+        operation.operation_type = OperationType.CALLBACK
+        operation.status = OperationStatus.SUCCEEDED
+        operation.end_timestamp = datetime(2024, 1, 1, 12, 5, 0, tzinfo=UTC)
+
+        callback_details = Mock()
+        callback_details.result = '{"callback": "result"}'
+        callback_details.error = None
+        operation.callback_details = callback_details
+
+        event = Event.from_operation_finished(
+            operation, event_id=4, include_execution_data=True
+        )
+
+        assert event.event_type == "CallbackSucceeded"
+        assert (
+            event.callback_succeeded_details.result.payload == '{"callback": "result"}'
+        )
+
+    def test_from_operation_finished_callback_timed_out(self):
+        """Test converting timed out callback operation."""
+        from datetime import UTC, datetime
+        from unittest.mock import Mock
+
+        operation = Mock()
+        operation.operation_id = "callback-123"
+        operation.name = "test_callback"
+        operation.parent_id = "parent-123"
+        operation.operation_type = OperationType.CALLBACK
+        operation.status = OperationStatus.TIMED_OUT
+        operation.end_timestamp = datetime(2024, 1, 1, 12, 5, 0, tzinfo=UTC)
+
+        callback_details = Mock()
+        callback_details.result = None
+        callback_details.error = ErrorObject.from_message("Callback timed out")
+        operation.callback_details = callback_details
+
+        event = Event.from_operation_finished(operation, event_id=4)
+
+        assert event.event_type == "CallbackTimedOut"
+        assert (
+            event.callback_timed_out_details.error.payload.message
+            == "Callback timed out"
+        )
+
+    def test_from_operation_finished_chained_invoke_succeeded(self):
+        """Test converting succeeded chained invoke operation."""
+        from datetime import UTC, datetime
+        from unittest.mock import Mock
+
+        operation = Mock()
+        operation.operation_id = "invoke-123"
+        operation.name = "test_invoke"
+        operation.parent_id = "parent-123"
+        operation.operation_type = OperationType.CHAINED_INVOKE
+        operation.status = OperationStatus.SUCCEEDED
+        operation.end_timestamp = datetime(2024, 1, 1, 12, 5, 0, tzinfo=UTC)
+
+        chained_invoke_details = Mock()
+        chained_invoke_details.result = '{"invoke": "result"}'
+        chained_invoke_details.error = None
+        operation.chained_invoke_details = chained_invoke_details
+
+        event = Event.from_operation_finished(
+            operation, event_id=5, include_execution_data=True
+        )
+
+        assert event.event_type == "ChainedInvokeSucceeded"
+        assert (
+            event.chained_invoke_succeeded_details.result.payload
+            == '{"invoke": "result"}'
+        )
+
+    def test_from_operation_finished_chained_invoke_stopped(self):
+        """Test converting stopped chained invoke operation."""
+        from datetime import UTC, datetime
+        from unittest.mock import Mock
+
+        operation = Mock()
+        operation.operation_id = "invoke-123"
+        operation.name = "test_invoke"
+        operation.parent_id = "parent-123"
+        operation.operation_type = OperationType.CHAINED_INVOKE
+        operation.status = OperationStatus.STOPPED
+        operation.end_timestamp = datetime(2024, 1, 1, 12, 5, 0, tzinfo=UTC)
+
+        chained_invoke_details = Mock()
+        chained_invoke_details.result = None
+        chained_invoke_details.error = ErrorObject.from_message("Invoke stopped")
+        operation.chained_invoke_details = chained_invoke_details
+
+        event = Event.from_operation_finished(operation, event_id=5)
+
+        assert event.event_type == "ChainedInvokeStopped"
+        assert (
+            event.chained_invoke_stopped_details.error.payload.message
+            == "Invoke stopped"
+        )
+
+    def test_from_operation_finished_context_succeeded(self):
+        """Test converting succeeded context operation."""
+        from datetime import UTC, datetime
+        from unittest.mock import Mock
+
+        operation = Mock()
+        operation.operation_id = "context-123"
+        operation.name = "test_context"
+        operation.parent_id = "parent-123"
+        operation.operation_type = OperationType.CONTEXT
+        operation.status = OperationStatus.SUCCEEDED
+        operation.end_timestamp = datetime(2024, 1, 1, 12, 5, 0, tzinfo=UTC)
+
+        context_details = Mock()
+        context_details.result = '{"context": "result"}'
+        context_details.error = None
+        operation.context_details = context_details
+        operation.result = None
+        operation.error = None
+
+        event = Event.from_operation_finished(
+            operation, event_id=6, include_execution_data=True
+        )
+
+        assert event.event_type == "ContextSucceeded"
+        assert event.context_succeeded_details.result.payload == '{"context": "result"}'
+
+    def test_from_operation_finished_context_failed(self):
+        """Test converting failed context operation."""
+        from datetime import UTC, datetime
+        from unittest.mock import Mock
+
+        operation = Mock()
+        operation.operation_id = "context-123"
+        operation.name = "test_context"
+        operation.parent_id = "parent-123"
+        operation.operation_type = OperationType.CONTEXT
+        operation.status = OperationStatus.FAILED
+        operation.end_timestamp = datetime(2024, 1, 1, 12, 5, 0, tzinfo=UTC)
+
+        context_details = Mock()
+        context_details.result = None
+        context_details.error = ErrorObject.from_message("Context failed")
+        operation.context_details = context_details
+        operation.result = None
+        operation.error = None
+
+        event = Event.from_operation_finished(operation, event_id=6)
+
+        assert event.event_type == "ContextFailed"
+        assert event.context_failed_details.error.payload.message == "Context failed"
+
+    def test_from_operation_finished_no_end_timestamp(self):
+        """Test error when operation has no end timestamp."""
+        from unittest.mock import Mock
+
+        operation = Mock()
+        operation.end_timestamp = None
+
+        with pytest.raises(
+            InvalidParameterValueException,
+            match="Operation end timestamp cannot be None",
+        ):
+            Event.from_operation_finished(operation, event_id=1)
+
+    def test_from_operation_finished_invalid_status(self):
+        """Test error with invalid operation status."""
+        from datetime import UTC, datetime
+        from unittest.mock import Mock
+
+        operation = Mock()
+        operation.status = OperationStatus.STARTED
+        operation.end_timestamp = datetime(2024, 1, 1, 12, 5, 0, tzinfo=UTC)
+
+        with pytest.raises(
+            InvalidParameterValueException,
+            match="Operation status must be one of SUCCEEDED, FAILED, TIMED_OUT, STOPPED, or CANCELLED",
+        ):
+            Event.from_operation_finished(operation, event_id=1)
+
+    def test_from_operation_finished_unknown_type(self):
+        """Test error with unknown operation type."""
+        from datetime import UTC, datetime
+        from unittest.mock import Mock
+
+        operation = Mock()
+        operation.operation_type = "UNKNOWN_TYPE"
+        operation.status = OperationStatus.SUCCEEDED
+        operation.end_timestamp = datetime(2024, 1, 1, 12, 5, 0, tzinfo=UTC)
+
+        with pytest.raises(
+            InvalidParameterValueException, match="Unknown operation type: UNKNOWN_TYPE"
+        ):
+            Event.from_operation_finished(operation, event_id=1)
+
+    def test_from_operation_finished_no_details(self):
+        """Test operations with no detail objects."""
+        from datetime import UTC, datetime
+        from unittest.mock import Mock
+
+        operation = Mock()
+        operation.operation_id = "step-123"
+        operation.name = "test_step"
+        operation.parent_id = "parent-123"
+        operation.operation_type = OperationType.STEP
+        operation.status = OperationStatus.SUCCEEDED
+        operation.end_timestamp = datetime(2024, 1, 1, 12, 5, 0, tzinfo=UTC)
+        operation.step_details = None
+
+        event = Event.from_operation_finished(operation, event_id=2)
+
+        assert event.event_type == "StepSucceeded"
+        assert event.step_succeeded_details.result is None
+
+
+# endregion from_operation_finished_tests

--- a/tests/executor_test.py
+++ b/tests/executor_test.py
@@ -1938,6 +1938,7 @@ def test_get_execution_state_invalid_token(executor, mock_store):
 def test_get_execution_history(executor, mock_store):
     """Test get_execution_history method."""
     mock_execution = Mock()
+    mock_execution.operations = []  # Empty operations list
     mock_store.load.return_value = mock_execution
 
     result = executor.get_execution_history("test-arn")
@@ -1945,6 +1946,115 @@ def test_get_execution_history(executor, mock_store):
     assert result.events == []
     assert result.next_marker is None
     mock_store.load.assert_called_once_with("test-arn")
+
+
+def test_get_execution_history_with_events(executor, mock_store):
+    """Test get_execution_history with actual events."""
+    from aws_durable_execution_sdk_python.lambda_service import StepDetails
+
+    # Create operations that will generate events
+    op1 = Operation(
+        operation_id="op-1",
+        operation_type=OperationType.STEP,
+        status=OperationStatus.SUCCEEDED,
+        start_timestamp=datetime.now(UTC),
+        end_timestamp=datetime.now(UTC),
+        step_details=StepDetails(result="test_result"),
+    )
+
+    mock_execution = Mock()
+    mock_execution.operations = [op1]
+    mock_store.load.return_value = mock_execution
+
+    result = executor.get_execution_history("test-arn", include_execution_data=True)
+
+    assert len(result.events) == 2  # Started + Succeeded events
+    assert result.events[0].event_type == "StepStarted"
+    assert result.events[1].event_type == "StepSucceeded"
+
+
+def test_get_execution_history_reverse_order(executor, mock_store):
+    """Test get_execution_history with reverse order."""
+    op1 = Operation(
+        operation_id="op-1",
+        operation_type=OperationType.STEP,
+        status=OperationStatus.SUCCEEDED,
+        start_timestamp=datetime.now(UTC),
+        end_timestamp=datetime.now(UTC),
+    )
+
+    mock_execution = Mock()
+    mock_execution.operations = [op1]
+    mock_store.load.return_value = mock_execution
+
+    result = executor.get_execution_history("test-arn", reverse_order=True)
+
+    assert len(result.events) == 2
+    # In reverse order, succeeded event should come first
+    assert result.events[0].event_type == "StepSucceeded"
+    assert result.events[1].event_type == "StepStarted"
+
+
+def test_get_execution_history_pagination(executor, mock_store):
+    """Test get_execution_history with pagination."""
+    # Create multiple operations to generate many events
+    operations = []
+    for i in range(3):
+        op = Operation(
+            operation_id=f"op-{i}",
+            operation_type=OperationType.STEP,
+            status=OperationStatus.SUCCEEDED,
+            start_timestamp=datetime.now(UTC),
+            end_timestamp=datetime.now(UTC),
+        )
+        operations.append(op)
+
+    mock_execution = Mock()
+    mock_execution.operations = operations
+    mock_store.load.return_value = mock_execution
+
+    # Test with max_items=2
+    result = executor.get_execution_history("test-arn", max_items=2)
+
+    assert len(result.events) == 2
+    assert result.next_marker == "3"  # Next event_id
+
+
+def test_get_execution_history_pagination_with_marker(executor, mock_store):
+    """Test get_execution_history pagination with marker."""
+    operations = []
+    for i in range(3):
+        op = Operation(
+            operation_id=f"op-{i}",
+            operation_type=OperationType.STEP,
+            status=OperationStatus.SUCCEEDED,
+            start_timestamp=datetime.now(UTC),
+            end_timestamp=datetime.now(UTC),
+        )
+        operations.append(op)
+
+    mock_execution = Mock()
+    mock_execution.operations = operations
+    mock_store.load.return_value = mock_execution
+
+    # Test with marker (start from event_id 3)
+    result = executor.get_execution_history("test-arn", marker="3", max_items=2)
+
+    assert len(result.events) == 2
+    # Should get events with event_id >= 3
+
+
+def test_get_execution_history_invalid_marker(executor, mock_store):
+    """Test get_execution_history with invalid marker."""
+    mock_execution = Mock()
+    mock_execution.operations = []
+    mock_store.load.return_value = mock_execution
+
+    # Invalid marker should default to 1
+    result = executor.get_execution_history("test-arn", marker="invalid")
+
+    assert result.events == []
+    assert result.next_marker is None
 
 
 def test_checkpoint_execution(executor, mock_store):


### PR DESCRIPTION
*Issue #, if available:*
closes #37
*Description of changes:*
- Add event_conversion module to transform operations into history events
- Implement operation_to_started_event and operation_to_finished_event
- Add generate_execution_events for complete execution history
- Update executor get_execution_history with proper cursor-based pagination
- Support reverse_order and include_execution_data options
- Add comprehensive test coverage for event conversion and pagination

## Dependencies
If this PR requires testing against a specific branch of the Python Language SDK (e.g., for unreleased changes), uncomment and specify the branch below. Otherwise, leave commented to use the main branch.

<!-- PYTHON_LANGUAGE_SDK_BRANCH: main -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
