### PR TITLE
fix: store execution before invoke

### DIFF
--- a/src/aws_durable_execution_sdk_python_testing/executor.py
+++ b/src/aws_durable_execution_sdk_python_testing/executor.py
@@ -646,6 +646,8 @@ class Executor(ExecutionObserver):
                     self._invoker.create_invocation_input(execution=execution)
                 )
 
+                self._store.save(execution)
+
                 response: DurableExecutionInvocationOutput = self._invoker.invoke(
                     execution.start_input.function_name, invocation_input
                 )


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*
- persist execution object before we send the invoke request to lambda side

## Dependencies
If this PR requires testing against a specific branch of the Python Language SDK (e.g., for unreleased changes), uncomment and specify the branch below. Otherwise, leave commented to use the main branch.

<!-- PYTHON_LANGUAGE_SDK_BRANCH: main -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
