### PR TITLE
fix: make retry examples using seeded random

### DIFF
--- a/examples/src/step/step_with_retry.py
+++ b/examples/src/step/step_with_retry.py
@@ -1,4 +1,4 @@
-from random import random
+from itertools import count
 from typing import Any
 
 from aws_durable_execution_sdk_python.config import StepConfig
@@ -14,13 +14,19 @@ from aws_durable_execution_sdk_python.retries import (
 )
 
 
+# Counter for deterministic behavior across retries
+_attempts = count(1)  # starts from 1
+
+
 @durable_step
 def unreliable_operation(
     _step_context: StepContext,
 ) -> str:
-    failure_threshold = 0.5
-    if random() > failure_threshold:  # noqa: S311
-        msg = "Random error occurred"
+    # Use counter for deterministic behavior
+    # Will fail on first attempt, succeed on second
+    attempt = next(_attempts)
+    if attempt < 2:
+        msg = f"Attempt {attempt} failed"
         raise RuntimeError(msg)
     return "Operation succeeded"
 

--- a/examples/test/step/test_step_with_retry.py
+++ b/examples/test/step/test_step_with_retry.py
@@ -3,7 +3,6 @@
 import pytest
 from aws_durable_execution_sdk_python.execution import InvocationStatus
 from aws_durable_execution_sdk_python.lambda_service import OperationType
-
 from src.step import step_with_retry
 from test.conftest import deserialize_operation_payload
 
@@ -14,20 +13,28 @@ from test.conftest import deserialize_operation_payload
     lambda_function_name="step with retry",
 )
 def test_step_with_retry(durable_runner):
-    """Test step with retry configuration."""
+    """Test step with retry configuration.
+
+    With counter-based deterministic behavior:
+    - Attempt 1: counter = 1 < 2 → raises RuntimeError ❌
+    - Attempt 2: counter = 2 >= 2 → succeeds ✓
+
+    The function deterministically fails once then succeeds on the second attempt.
+    """
     with durable_runner:
         result = durable_runner.run(input="test", timeout=30)
 
-    # The function uses random() so it may succeed or fail
-    # We just verify it completes and has retry configuration
-    assert result.status in [InvocationStatus.SUCCEEDED, InvocationStatus.FAILED]
+    # With counter-based deterministic behavior, succeeds on attempt 2
+    assert result.status is InvocationStatus.SUCCEEDED
+    assert deserialize_operation_payload(result.result) == "Operation succeeded"
 
-    # Verify step operation exists
+    # Verify step operation exists with retry details
     step_ops = [
         op for op in result.operations if op.operation_type == OperationType.STEP
     ]
-    assert len(step_ops) >= 1
+    assert len(step_ops) == 1
 
-    # If it succeeded, verify the result
-    if result.status is InvocationStatus.SUCCEEDED:
-        assert deserialize_operation_payload(result.result) == "Operation succeeded"
+    # The step should have succeeded on attempt 2 (after 1 failure)
+    # Attempt numbering: 1 (initial attempt), 2 (first retry)
+    step_op = step_ops[0]
+    assert step_op.attempt == 2  # Succeeded on first retry (1-indexed: 2=first retry)

--- a/examples/test/step/test_steps_with_retry.py
+++ b/examples/test/step/test_steps_with_retry.py
@@ -3,7 +3,6 @@
 import pytest
 from aws_durable_execution_sdk_python.execution import InvocationStatus
 from aws_durable_execution_sdk_python.lambda_service import OperationType
-
 from src.step import steps_with_retry
 from test.conftest import deserialize_operation_payload
 
@@ -14,20 +13,40 @@ from test.conftest import deserialize_operation_payload
     lambda_function_name="steps with retry",
 )
 def test_steps_with_retry(durable_runner):
-    """Test steps_with_retry pattern."""
+    """Test steps_with_retry pattern.
+
+    With counter-based deterministic behavior:
+    - Poll 1, Attempt 1: counter = 1 → raises RuntimeError ❌
+    - Poll 1, Attempt 2: counter = 2 → returns None
+    - Poll 2, Attempt 1: counter = 3 → returns item ✓
+
+    The function finds the item on poll 2 after 1 retry on poll 1.
+    """
     with durable_runner:
         result = durable_runner.run(input={"name": "test-item"}, timeout=30)
 
     assert result.status is InvocationStatus.SUCCEEDED
 
-    # Result should be either success with item or error
-    assert isinstance(deserialize_operation_payload(result.result), dict)
-    assert "success" in deserialize_operation_payload(
-        result.result
-    ) or "error" in deserialize_operation_payload(result.result)
+    # With counter-based deterministic behavior, finds item on poll 2
+    result_data = deserialize_operation_payload(result.result)
+    assert isinstance(result_data, dict)
+    assert result_data.get("success") is True
+    assert result_data.get("pollsRequired") == 2
+    assert "item" in result_data
+    assert result_data["item"]["id"] == "test-item"
 
-    # Verify step operations exist (polling steps)
+    # Verify step operations exist
     step_ops = [
         op for op in result.operations if op.operation_type == OperationType.STEP
     ]
-    assert len(step_ops) >= 1
+    # Should have exactly 2 step operations (poll 1 and poll 2)
+    assert len(step_ops) == 2
+
+    # Poll 1: succeeded after 1 retry (returned None)
+    assert step_ops[0].name == "get_item_poll_1"
+    assert step_ops[0].result == "null"
+    assert step_ops[0].attempt == 2  # 1 retry occurred (1-indexed: 2=first retry)
+
+    # Poll 2: succeeded immediately (returned item)
+    assert step_ops[1].name == "get_item_poll_2"
+    assert step_ops[1].attempt == 1  # No retries needed (1-indexed: 1=initial)

--- a/tests/checkpoint/processors/step_test.py
+++ b/tests/checkpoint/processors/step_test.py
@@ -230,6 +230,7 @@ def test_process_succeed_action_with_current_operation():
 
     current_op = Mock()
     current_op.start_timestamp = datetime.now(UTC)
+    current_op.step_details = StepDetails()
 
     update = OperationUpdate(
         operation_id="step-123",
@@ -243,6 +244,7 @@ def test_process_succeed_action_with_current_operation():
 
     assert result.start_timestamp == current_op.start_timestamp
     assert result.status == OperationStatus.SUCCEEDED
+    assert result.step_details.attempt == 1
 
 
 def test_process_fail_action():
@@ -274,6 +276,7 @@ def test_process_fail_action_with_current_operation():
 
     current_op = Mock()
     current_op.start_timestamp = datetime.now(UTC)
+    current_op.step_details = StepDetails()
 
     error = ErrorObject.from_message("step failed")
     update = OperationUpdate(
@@ -288,6 +291,7 @@ def test_process_fail_action_with_current_operation():
 
     assert result.start_timestamp == current_op.start_timestamp
     assert result.status == OperationStatus.FAILED
+    assert result.step_details.attempt == 1
 
 
 def test_process_invalid_action():


### PR DESCRIPTION
*Issue #, if available:*
closes #93 
Changes:


1. `step_with_retry.py`:
    With counter-based deterministic behavior:
    - Attempt 1: counter = 1 < 2 → raises RuntimeError ❌
    - Attempt 2: counter = 2 >= 2 → succeeds ✓

2. `steps_with_retry.py`:
    With counter-based deterministic behavior:
    - Poll 1, Attempt 1: counter = 1 → raises RuntimeError ❌
    - Poll 1, Attempt 2: counter = 2 → returns None
    - Poll 2, Attempt 1: counter = 3 → returns item ✓

## Dependencies
If this PR requires testing against a specific branch of the Python Language SDK (e.g., for unreleased changes), uncomment and specify the branch below. Otherwise, leave commented to use the main branch.

<!-- PYTHON_LANGUAGE_SDK_BRANCH: main -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
