### PR TITLE
fix: invoke lambda after callback success/failure

### DIFF
--- a/src/aws_durable_execution_sdk_python_testing/checkpoint/processor.py
+++ b/src/aws_durable_execution_sdk_python_testing/checkpoint/processor.py
@@ -71,15 +71,15 @@ class CheckpointProcessor:
             execution_arn=token.execution_arn,
         )
 
-        # 5. Save update
+        # 5. Generate a new checkpoint token and save updated operations
+        new_checkpoint_token = execution.get_new_checkpoint_token()
         execution.operations = updated_operations
         execution.updates.extend(all_updates)
-
         self._store.update(execution)
 
         # 6. Return checkpoint result
         return CheckpointOutput(
-            checkpoint_token=execution.get_new_checkpoint_token(),
+            checkpoint_token=new_checkpoint_token,
             new_execution_state=CheckpointUpdatedExecutionState(
                 operations=execution.get_navigable_operations(), next_marker=None
             ),


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Bug fix -- we need to reinvoke the function after the callback is resolved in success/failure modes. We were incorrectly reinvoking the function when the timeout was reached instead.

## Dependencies
If this PR requires testing against a specific branch of the Python Language SDK (e.g., for unreleased changes), uncomment and specify the branch below. Otherwise, leave commented to use the main branch.

<!-- PYTHON_LANGUAGE_SDK_BRANCH: main -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
