### PR TITLE
feat: Implement send callback request for local runner

### DIFF
--- a/examples/examples-catalog.json
+++ b/examples/examples-catalog.json
@@ -79,10 +79,21 @@
       "path": "./src/callback/callback.py"
     },
     {
-      "name": "Wait for Callback",
+      "name": "Wait for Callback Success",
       "description": "Usage of context.wait_for_callback() to wait for external system responses",
       "handler": "wait_for_callback.handler",
-      "integration": false,
+      "integration": true,
+      "durableConfig": {
+        "RetentionPeriodInDays": 7,
+        "ExecutionTimeout": 300
+      },
+      "path": "./src/wait_for_callback/wait_for_callback.py"
+    },
+    {
+      "name": "Wait for Callback Failure",
+      "description": "Usage of context.wait_for_callback() to wait for external system responses",
+      "handler": "wait_for_callback.handler",
+      "integration": true,
       "durableConfig": {
         "RetentionPeriodInDays": 7,
         "ExecutionTimeout": 300

--- a/examples/src/hello_world.py
+++ b/examples/src/hello_world.py
@@ -1,10 +1,62 @@
-from typing import Any
+"""Simple durable Lambda handler example.
 
-from aws_durable_execution_sdk_python.context import DurableContext
+This example demonstrates:
+- Step execution with logging
+- Wait operations (pausing without consuming resources)
+- Replay-aware logging
+- Returning a response
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from aws_durable_execution_sdk_python.config import Duration
+from aws_durable_execution_sdk_python.context import DurableContext, durable_step
 from aws_durable_execution_sdk_python.execution import durable_execution
+
+if TYPE_CHECKING:
+    from aws_durable_execution_sdk_python.types import StepContext
+
+
+@durable_step
+def step_1(step_context: StepContext) -> None:
+    """First step that logs a message."""
+    step_context.logger.info("Hello from step1")
+
+
+@durable_step
+def step_2(step_context: StepContext, status_code: int) -> str:
+    """Second step that returns a message."""
+    step_context.logger.info("Returning message with status code: %d", status_code)
+    return f"Hello from Durable Lambda! (status: {status_code})"
 
 
 @durable_execution
-def handler(_event: Any, _context: DurableContext) -> str:
-    """Simple hello world durable function."""
-    return "Hello World!"
+def handler(event: Any, context: DurableContext) -> dict[str, Any]:
+    """Durable Lambda handler with steps, waits, and logging.
+
+    Args:
+        event: Lambda event input
+        context: Durable execution context
+
+    Returns:
+        Response dictionary with statusCode and body
+    """
+    # Execute Step #1 - logs a message
+    context.step(step_1())
+
+    # Pause for 10 seconds without consuming CPU cycles or incurring usage charges
+    # The execution will suspend here and resume after 10 seconds
+    context.wait(Duration.from_seconds(10))
+
+    context.logger.info("Waited for 10 seconds")
+
+    # Execute Step #2 - returns a message with status code
+    message = context.step(step_2(status_code=200))
+
+    # Return response
+    return {
+        "statusCode": 200,
+        "body": message,
+    }

--- a/examples/test/conftest.py
+++ b/examples/test/conftest.py
@@ -10,7 +10,10 @@ from pathlib import Path
 from typing import Any
 
 import pytest
-from aws_durable_execution_sdk_python.lambda_service import OperationPayload
+from aws_durable_execution_sdk_python.lambda_service import (
+    ErrorObject,
+    OperationPayload,
+)
 from aws_durable_execution_sdk_python.serdes import ExtendedTypeSerDes
 
 from aws_durable_execution_sdk_python_testing.runner import (
@@ -112,11 +115,15 @@ class TestRunnerAdapter:
     ) -> str:
         return self._runner.run_async(input=input, timeout=timeout)
 
-    def send_callback_success(self, callback_id: str) -> None:
-        self._runner.send_callback_success(callback_id=callback_id)
+    def send_callback_success(
+        self, callback_id: str, result: bytes | None = None
+    ) -> None:
+        self._runner.send_callback_success(callback_id=callback_id, result=result)
 
-    def send_callback_failure(self, callback_id: str) -> None:
-        self._runner.send_callback_failure(callback_id=callback_id)
+    def send_callback_failure(
+        self, callback_id: str, error: ErrorObject | None = None
+    ) -> None:
+        self._runner.send_callback_failure(callback_id=callback_id, error=error)
 
     def send_callback_heartbeat(self, callback_id: str) -> None:
         self._runner.send_callback_heartbeat(callback_id=callback_id)

--- a/examples/test/test_hello_world.py
+++ b/examples/test/test_hello_world.py
@@ -15,7 +15,10 @@ from test.conftest import deserialize_operation_payload
 def test_hello_world(durable_runner):
     """Test hello world example."""
     with durable_runner:
-        result = durable_runner.run(input="test", timeout=10)
+        result = durable_runner.run(input="test", timeout=30)
 
     assert result.status is InvocationStatus.SUCCEEDED
-    assert deserialize_operation_payload(result.result) == "Hello World!"
+    assert deserialize_operation_payload(result.result) == {
+        "statusCode": 200,
+        "body": "Hello from Durable Lambda! (status: 200)",
+    }

--- a/examples/test/wait_for_callback/test_wait_for_callback_failure.py
+++ b/examples/test/wait_for_callback/test_wait_for_callback_failure.py
@@ -1,0 +1,27 @@
+import pytest
+from aws_durable_execution_sdk_python.execution import InvocationStatus
+from aws_durable_execution_sdk_python.lambda_service import ErrorObject
+
+from src.wait_for_callback import wait_for_callback
+
+
+@pytest.mark.example
+@pytest.mark.durable_execution(
+    handler=wait_for_callback.handler,
+    lambda_function_name="Wait For Callback Failure",
+)
+def test_wait_for_callback_failure(durable_runner):
+    with durable_runner:
+        execution_arn = durable_runner.run_async(input="test", timeout=30)
+        callback_id = durable_runner.wait_for_callback(execution_arn=execution_arn)
+        durable_runner.send_callback_failure(
+            callback_id=callback_id, error=ErrorObject.from_message("my callback error")
+        )
+        result = durable_runner.wait_for_result(execution_arn=execution_arn)
+
+    assert result.status is InvocationStatus.FAILED
+    assert isinstance(result.error, ErrorObject)
+    assert result.error.to_dict() == {
+        "ErrorMessage": "my callback error",
+        "ErrorType": "CallableRuntimeError",
+    }

--- a/examples/test/wait_for_callback/test_wait_for_callback_success.py
+++ b/examples/test/wait_for_callback/test_wait_for_callback_success.py
@@ -1,0 +1,25 @@
+import pytest
+from aws_durable_execution_sdk_python.execution import InvocationStatus
+
+from src.wait_for_callback import wait_for_callback
+from test.conftest import deserialize_operation_payload
+
+
+@pytest.mark.example
+@pytest.mark.durable_execution(
+    handler=wait_for_callback.handler,
+    lambda_function_name="Wait For Callback Success",
+)
+def test_wait_for_callback_success(durable_runner):
+    with durable_runner:
+        execution_arn = durable_runner.run_async(input="test", timeout=30)
+        callback_id = durable_runner.wait_for_callback(execution_arn=execution_arn)
+        durable_runner.send_callback_success(
+            callback_id=callback_id, result="callback success".encode()
+        )
+        result = durable_runner.wait_for_result(execution_arn=execution_arn)
+    assert result.status is InvocationStatus.SUCCEEDED
+    assert (
+        deserialize_operation_payload(result.result)
+        == "External system result: callback success"
+    )


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Implement send callback request for local runner
- Add wait for callback support for local runner
- Add optional result and error to cloud runner send callback handler
- Add wait for callback test cases
- Updated the Hello World example originally authored by Mr. Thomas

## Dependencies
If this PR requires testing against a specific branch of the Python Language SDK (e.g., for unreleased changes), uncomment and specify the branch below. Otherwise, leave commented to use the main branch.

<!-- PYTHON_LANGUAGE_SDK_BRANCH: main -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
