### PR TITLE
fix: add missing DurableExecutionArn to StopDurableExecution request …

### DIFF
--- a/src/aws_durable_execution_sdk_python_testing/web/handlers.py
+++ b/src/aws_durable_execution_sdk_python_testing/web/handlers.py
@@ -387,13 +387,15 @@ class StopDurableExecutionHandler(EndpointHandler):
             HTTPResponse: The HTTP response to send to the client
         """
         try:
-            body_data: dict[str, Any] = self._parse_json_body(request)
-            stop_request: StopDurableExecutionRequest = (
-                StopDurableExecutionRequest.from_dict(body_data)
-            )
+            body_data: dict[str, Any] = self._parse_json_body_optional(request)
 
             stop_route = cast(StopDurableExecutionRoute, parsed_route)
             execution_arn: str = stop_route.arn
+
+            body_data["DurableExecutionArn"] = execution_arn
+            stop_request: StopDurableExecutionRequest = (
+                StopDurableExecutionRequest.from_dict(body_data)
+            )
 
             stop_response: StopDurableExecutionResponse = self.executor.stop_execution(
                 execution_arn, stop_request.error


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Fixed StopDurableExecutionHandler to extract ARN from URL path and add to request body
- Resolves mismatch between API spec (ARN in URI) and from_dict() expectation (ARN in body)
- Enables samdev local execution stop command to work properly
- Errors fixed:
   - "Request body is required" error (no error params)
   - "'DurableExecutionArn'" KeyError (with error params)





## Dependencies
If this PR requires testing against a specific branch of the Python Language SDK (e.g., for unreleased changes), uncomment and specify the branch below. Otherwise, leave commented to use the main branch.

<!-- PYTHON_LANGUAGE_SDK_BRANCH: main -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
