### PR TITLE
feat: add DURABLE_EXECUTION_TIME_SCALE env var for wait scaling

### DIFF
--- a/src/aws_durable_execution_sdk_python_testing/model.py
+++ b/src/aws_durable_execution_sdk_python_testing/model.py
@@ -1760,7 +1760,7 @@ class Event:
             and wait_details.scheduled_end_timestamp
             and context.operation.start_timestamp
         ):
-            duration = int(
+            duration = round(
                 (
                     wait_details.scheduled_end_timestamp
                     - context.operation.start_timestamp
@@ -1789,7 +1789,7 @@ class Event:
             and wait_details.scheduled_end_timestamp
             and context.operation.start_timestamp
         ):
-            duration = int(
+            duration = round(
                 (
                     wait_details.scheduled_end_timestamp - context.start_timestamp
                 ).total_seconds()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- add DURABLE_EXECUTION_TIME_SCALE environment variable support in WaitProcessor
- scale wait times and scheduled timestamps using the environment variable
- fix duration calculation rounding issue in event history (use round() instead of int())

## Dependencies
If this PR requires testing against a specific branch of the Python Language SDK (e.g., for unreleased changes), uncomment and specify the branch below. Otherwise, leave commented to use the main branch.

<!-- PYTHON_LANGUAGE_SDK_BRANCH: main -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
