### PR TITLE
fix: fix double encoding for execution input

### DIFF
--- a/src/aws_durable_execution_sdk_python_testing/execution.py
+++ b/src/aws_durable_execution_sdk_python_testing/execution.py
@@ -161,7 +161,7 @@ class Execution:
                     operation_type=OperationType.EXECUTION,
                     status=OperationStatus.STARTED,
                     execution_details=ExecutionDetails(
-                        input_payload=json.dumps(self.start_input.input)
+                        input_payload=self.start_input.get_normalized_input()
                     ),
                 )
             )

--- a/src/aws_durable_execution_sdk_python_testing/model.py
+++ b/src/aws_durable_execution_sdk_python_testing/model.py
@@ -6,6 +6,7 @@ import datetime
 from dataclasses import dataclass, replace
 from enum import Enum
 from typing import Any
+import json
 
 from dateutil.tz import UTC
 
@@ -165,6 +166,19 @@ class StartDurableExecutionInput:
         if self.input is not None:
             result["Input"] = self.input
         return result
+
+    def get_normalized_input(self):
+        """
+        Normalize input string to be JSON deserializable.
+        Avoid double coding json input.
+        """
+        # Try to parse once
+        try:
+            _ = json.loads(self.input)
+            return self.input
+        except (json.JSONDecodeError, TypeError):
+            # Not valid JSON, treat as plain string and encode it
+            return json.dumps(self.input)
 
 
 @dataclass(frozen=True)

--- a/tests/execution_test.py
+++ b/tests/execution_test.py
@@ -99,7 +99,7 @@ def test_execution_start(mock_datetime):
     assert operation.start_timestamp == mock_now
     assert operation.operation_type == OperationType.EXECUTION
     assert operation.status == OperationStatus.STARTED
-    assert operation.execution_details.input_payload == '"{\\"key\\": \\"value\\"}"'
+    assert operation.execution_details.input_payload == '{"key": "value"}'
 
 
 def test_get_operation_execution_started():

--- a/tests/model_test.py
+++ b/tests/model_test.py
@@ -77,21 +77,23 @@ TIMESTAMP_2023_01_01_00_01 = datetime.datetime(2023, 1, 1, 0, 1, 0, tzinfo=datet
 TIMESTAMP_2023_01_01_00_02 = datetime.datetime(2023, 1, 1, 0, 2, 0, tzinfo=datetime.UTC)
 TIMESTAMP_2023_01_02_00_00 = datetime.datetime(2023, 1, 2, 0, 0, 0, tzinfo=datetime.UTC)
 
+DEFAULT_START_DURABLE_EXECUTION_INPUT_DATA = {
+    "AccountId": "123456789012",
+    "FunctionName": "my-function",
+    "FunctionQualifier": "$LATEST",
+    "ExecutionName": "test-execution",
+    "ExecutionTimeoutSeconds": 300,
+    "ExecutionRetentionPeriodDays": 7,
+    "InvocationId": "invocation-123",
+    "TraceFields": {"key": "value"},
+    "TenantId": "tenant-123",
+    "Input": "test-input",
+}
+
 
 def test_start_durable_execution_input_serialization():
     """Test StartDurableExecutionInput from_dict/to_dict round-trip."""
-    data = {
-        "AccountId": "123456789012",
-        "FunctionName": "my-function",
-        "FunctionQualifier": "$LATEST",
-        "ExecutionName": "test-execution",
-        "ExecutionTimeoutSeconds": 300,
-        "ExecutionRetentionPeriodDays": 7,
-        "InvocationId": "invocation-123",
-        "TraceFields": {"key": "value"},
-        "TenantId": "tenant-123",
-        "Input": "test-input",
-    }
+    data = DEFAULT_START_DURABLE_EXECUTION_INPUT_DATA
 
     # Test from_dict
     input_obj = StartDurableExecutionInput.from_dict(data)
@@ -113,6 +115,42 @@ def test_start_durable_execution_input_serialization():
     # Test round-trip
     round_trip = StartDurableExecutionInput.from_dict(result_data)
     assert round_trip == input_obj
+
+
+def test_start_durable_execution_input_get_input_json_input():
+    """Test StartDurableExecutionInput from_dict/to_dict round-trip."""
+    data = DEFAULT_START_DURABLE_EXECUTION_INPUT_DATA
+    data["Input"] = '{"message": "hello"}'
+
+    input_obj = StartDurableExecutionInput.from_dict(data)
+    assert '{"message": "hello"}' == input_obj.get_normalized_input()
+
+
+def test_start_durable_execution_input_get_input_str_non_json_input():
+    """Test StartDurableExecutionInput from_dict/to_dict round-trip."""
+    data = DEFAULT_START_DURABLE_EXECUTION_INPUT_DATA
+    data["Input"] = "hello"
+
+    input_obj = StartDurableExecutionInput.from_dict(data)
+    assert '"hello"' == input_obj.get_normalized_input()
+
+
+def test_start_durable_execution_input_get_input_str_json_input():
+    """Test StartDurableExecutionInput from_dict/to_dict round-trip."""
+    data = DEFAULT_START_DURABLE_EXECUTION_INPUT_DATA
+    data["Input"] = '"hello"'
+
+    input_obj = StartDurableExecutionInput.from_dict(data)
+    assert '"hello"' == input_obj.get_normalized_input()
+
+
+def test_start_durable_execution_input_get_input_list_json_input():
+    """Test StartDurableExecutionInput from_dict/to_dict round-trip."""
+    data = DEFAULT_START_DURABLE_EXECUTION_INPUT_DATA
+    data["Input"] = "[1,2,3]"
+
+    input_obj = StartDurableExecutionInput.from_dict(data)
+    assert "[1,2,3]" == input_obj.get_normalized_input()
 
 
 def test_start_durable_execution_input_minimal():


### PR DESCRIPTION
- Check the input str before we serialize it to avoid double encoding for JSON input

*Issue #, if available:*

*Description of changes:*

## Dependencies
If this PR requires testing against a specific branch of the Python Language SDK (e.g., for unreleased changes), uncomment and specify the branch below. Otherwise, leave commented to use the main branch.

<!-- PYTHON_LANGUAGE_SDK_BRANCH: main -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
