### PR TITLE
feat: add per-execution lambda endpoint support

### DIFF
--- a/src/aws_durable_execution_sdk_python_testing/executor.py
+++ b/src/aws_durable_execution_sdk_python_testing/executor.py
@@ -106,6 +106,7 @@ class Executor(ExecutionObserver):
                 trace_fields=input.trace_fields,
                 tenant_id=input.tenant_id,
                 input=input.input,
+                lambda_endpoint=input.lambda_endpoint,
             )
 
         execution = Execution.new(input=input)

--- a/src/aws_durable_execution_sdk_python_testing/model.py
+++ b/src/aws_durable_execution_sdk_python_testing/model.py
@@ -117,6 +117,7 @@ class StartDurableExecutionInput:
     trace_fields: dict | None = None
     tenant_id: str | None = None
     input: str | None = None
+    lambda_endpoint: str | None = None  # Endpoint for this specific execution
 
     @classmethod
     def from_dict(cls, data: dict) -> StartDurableExecutionInput:
@@ -146,6 +147,7 @@ class StartDurableExecutionInput:
             trace_fields=data.get("TraceFields"),
             tenant_id=data.get("TenantId"),
             input=data.get("Input"),
+            lambda_endpoint=data.get("LambdaEndpoint", None),
         )
 
     def to_dict(self) -> dict[str, Any]:
@@ -165,6 +167,8 @@ class StartDurableExecutionInput:
             result["TenantId"] = self.tenant_id
         if self.input is not None:
             result["Input"] = self.input
+        if self.lambda_endpoint is not None:
+            result["LambdaEndpoint"] = self.lambda_endpoint
         return result
 
     def get_normalized_input(self):


### PR DESCRIPTION

*Issue #, if available:*
closes #151 
*Description of changes:*
- Add lambda_endpoint field to StartDurableExecutionInput
- Cache clients by endpoint to avoid race conditions
- Maintain backward compatibility

## Dependencies
If this PR requires testing against a specific branch of the Python Language SDK (e.g., for unreleased changes), uncomment and specify the branch below. Otherwise, leave commented to use the main branch.

<!-- PYTHON_LANGUAGE_SDK_BRANCH: main -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
