### PR TITLE
fix: parse callback result from body directly

### DIFF
--- a/src/aws_durable_execution_sdk_python_testing/web/handlers.py
+++ b/src/aws_durable_execution_sdk_python_testing/web/handlers.py
@@ -187,13 +187,11 @@ class EndpointHandler(ABC):
     def _parse_callback_result_payload(self, request: HTTPRequest) -> bytes:
         """Parse callback result payload from request body.
 
-        Expects JSON payload with base64-encoded Result field.
-
         Args:
-            request: The HTTP request containing the JSON payload
+            request: The HTTP request containing the binary payload
 
         Returns:
-            bytes: The decoded result payload
+            bytes: The result payload
 
         Raises:
             InvalidParameterValueException: If payload parsing fails
@@ -201,19 +199,7 @@ class EndpointHandler(ABC):
         if not request.body or not isinstance(request.body, bytes):
             return b""
 
-        try:
-            payload = json.loads(request.body.decode("utf-8"))
-            if isinstance(payload, dict) and "Result" in payload:
-                result_value = payload["Result"]
-                if isinstance(result_value, str):
-                    return base64.b64decode(result_value)
-            return b""
-        except (json.JSONDecodeError, UnicodeDecodeError) as e:
-            msg = f"Failed to parse JSON payload: {e}"
-            raise InvalidParameterValueException(msg) from e
-        except ValueError as e:
-            msg = f"Failed to decode base64 result: {e}"
-            raise InvalidParameterValueException(msg) from e
+        return request.body
 
     def _parse_query_param(self, request: HTTPRequest, param_name: str) -> str | None:
         """Parse a single query parameter from the request.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Small bug fix - our deserialization here was wrong. We need to read the request body as bytes directly.

## Dependencies
If this PR requires testing against a specific branch of the Python Language SDK (e.g., for unreleased changes), uncomment and specify the branch below. Otherwise, leave commented to use the main branch.

<!-- PYTHON_LANGUAGE_SDK_BRANCH: main -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
