### PR TITLE
chore: set botocore logging to warning

### DIFF
--- a/src/aws_durable_execution_sdk_python_testing/cli.py
+++ b/src/aws_durable_execution_sdk_python_testing/cli.py
@@ -115,6 +115,7 @@ class CliApp:
                 level=level,
                 format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
             )
+            logging.getLogger("botocore").setLevel(logging.WARNING)
 
             # Execute the appropriate command
             return parsed_args.func(parsed_args)

--- a/src/aws_durable_execution_sdk_python_testing/web/server.py
+++ b/src/aws_durable_execution_sdk_python_testing/web/server.py
@@ -188,6 +188,7 @@ class WebServer(ThreadingHTTPServer):
 
         # Configure logging
         logging.basicConfig(level=config.log_level)
+        logging.getLogger("botocore").setLevel(logging.WARNING)
 
         # Create shared router and endpoint handlers
         self.router = Router()  # Shared across all request handlers


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Setting the botocore logger to `WARNING` so that the debug logger is less noisy in the emulator server.

## Dependencies
If this PR requires testing against a specific branch of the Python Language SDK (e.g., for unreleased changes), uncomment and specify the branch below. Otherwise, leave commented to use the main branch.

<!-- PYTHON_LANGUAGE_SDK_BRANCH: main -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
