### PR TITLE
fix: increase max_retries for acceptance tests function create

### DIFF
--- a/examples/cli.py
+++ b/examples/cli.py
@@ -345,6 +345,7 @@ def deploy_function(example_name: str, function_name: str | None = None):
             lambda_client.update_function_code,
             FunctionName=function_name,
             ZipFile=zip_content,
+            max_retries=8,
         )
         retry_on_resource_conflict(
             lambda_client.update_function_configuration, **function_config


### PR DESCRIPTION
*Description of changes:*

- Sometimes the function is still being deleted when we exausted the default 5 retries. Increase max_retry for function creation to 8.
- It will retry up to 64 seconds (~1 min)
- This prevent tests failure when you re-run the checks (e.g. by pushing a new commit)


## Dependencies
If this PR requires testing against a specific branch of the Python Language SDK (e.g., for unreleased changes), uncomment and specify the branch below. Otherwise, leave commented to use the main branch.

<!-- PYTHON_LANGUAGE_SDK_BRANCH: main -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
