### PR TITLE
refactor: use to/from_json_dict for operation serdes

### DIFF
--- a/src/aws_durable_execution_sdk_python_testing/execution.py
+++ b/src/aws_durable_execution_sdk_python_testing/execution.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 from dataclasses import replace
 from datetime import UTC, datetime
 from enum import Enum
@@ -33,7 +32,6 @@ from aws_durable_execution_sdk_python_testing.model import (
 )
 from aws_durable_execution_sdk_python_testing.token import (
     CheckpointToken,
-    CallbackToken,
 )
 
 
@@ -96,12 +94,12 @@ class Execution:
             durable_execution_arn=str(uuid4()), start_input=input, operations=[]
         )
 
-    def to_dict(self) -> dict[str, Any]:
-        """Serialize execution to dictionary."""
+    def to_json_dict(self) -> dict[str, Any]:
+        """Serialize execution to JSON-serializable dictionary"""
         return {
             "DurableExecutionArn": self.durable_execution_arn,
             "StartInput": self.start_input.to_dict(),
-            "Operations": [op.to_dict() for op in self.operations],
+            "Operations": [op.to_json_dict() for op in self.operations],
             "Updates": [update.to_dict() for update in self.updates],
             "InvocationCompletions": [
                 completion.to_dict() for completion in self.invocation_completions
@@ -115,13 +113,15 @@ class Execution:
         }
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> Execution:
+    def from_json_dict(cls, data: dict[str, Any]) -> Execution:
         """Deserialize execution from dictionary."""
         # Reconstruct start_input
         start_input = StartDurableExecutionInput.from_dict(data["StartInput"])
 
         # Reconstruct operations
-        operations = [Operation.from_dict(op_data) for op_data in data["Operations"]]
+        operations = [
+            Operation.from_json_dict(op_data) for op_data in data["Operations"]
+        ]
 
         # Create execution
         execution = cls(

--- a/src/aws_durable_execution_sdk_python_testing/invoker.py
+++ b/src/aws_durable_execution_sdk_python_testing/invoker.py
@@ -12,12 +12,10 @@ from aws_durable_execution_sdk_python.execution import (
     DurableExecutionInvocationInputWithClient,
     DurableExecutionInvocationOutput,
     InitialExecutionState,
-    InvocationStatus,
 )
 
 from aws_durable_execution_sdk_python_testing.exceptions import (
     DurableFunctionsTestError,
-    ServiceException,
 )
 from aws_durable_execution_sdk_python_testing.model import LambdaContext
 
@@ -239,7 +237,7 @@ class LambdaInvoker(Invoker):
             response = client.invoke(
                 FunctionName=function_name,
                 InvocationType="RequestResponse",  # Synchronous invocation
-                Payload=json.dumps(input.to_dict(), default=str),
+                Payload=json.dumps(input.to_json_dict()),
             )
 
             # Check HTTP status code

--- a/tests/execution_test.py
+++ b/tests/execution_test.py
@@ -18,7 +18,6 @@ from aws_durable_execution_sdk_python.lambda_service import (
 
 from aws_durable_execution_sdk_python_testing.exceptions import (
     IllegalStateException,
-    InvalidParameterValueException,
 )
 from aws_durable_execution_sdk_python_testing.execution import Execution
 from aws_durable_execution_sdk_python_testing.model import StartDurableExecutionInput
@@ -813,7 +812,7 @@ def test_from_dict_with_none_result():
         "aws_durable_execution_sdk_python_testing.model.StartDurableExecutionInput.from_dict"
     ) as mock_from_dict:
         mock_from_dict.return_value = Mock()
-        execution = Execution.from_dict(data)
+        execution = Execution.from_json_dict(data)
         assert execution.result is None
 
 

--- a/tests/how-to-run-from-term.txt
+++ b/tests/how-to-run-from-term.txt
@@ -1,1 +1,0 @@
-source /Users/rarepolz/workspace/aws-durable-execution/venv/bin/activate && pip install -e . --no-deps && pytest tests/event_conversion_test.py -v

--- a/tests/stores/filesystem_store_test.py
+++ b/tests/stores/filesystem_store_test.py
@@ -12,7 +12,6 @@ from aws_durable_execution_sdk_python_testing.execution import Execution
 from aws_durable_execution_sdk_python_testing.model import StartDurableExecutionInput
 from aws_durable_execution_sdk_python_testing.stores.filesystem import (
     FileSystemExecutionStore,
-    datetime_object_hook,
 )
 
 from datetime import datetime, timezone
@@ -267,19 +266,6 @@ def test_filesystem_execution_store_thread_safety_basic(store, sample_execution)
     store.save(sample_execution)
     loaded = store.load(sample_execution.durable_execution_arn)
     assert loaded.durable_execution_arn == sample_execution.durable_execution_arn
-
-
-def test_datetime_object_hook_converts_timestamp_fields():
-    """Test conversion of timestamp fields to datetime objects."""
-    timestamp = 1672531200.0  # 2023-01-01 00:00:00 UTC
-    obj = {
-        "start_timestamp": timestamp,
-    }
-
-    result = datetime_object_hook(obj)
-
-    expected_datetime = datetime.fromtimestamp(timestamp, tz=timezone.utc)
-    assert result["start_timestamp"] == expected_datetime
 
 
 def test_filesystem_execution_store_query_empty(store):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Remove customized json encoder
- Use `to_json_dict()` and `from_json_dict()` for Operation and ExecutionInput serdes

## Dependencies
If this PR requires testing against a specific branch of the Python Language SDK (e.g., for unreleased changes), uncomment and specify the branch below. Otherwise, leave commented to use the main branch.

<!-- PYTHON_LANGUAGE_SDK_BRANCH: main -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
