### PR TITLE
ci: v1.1.0 -> v1.1.1

### DIFF
--- a/src/aws_durable_execution_sdk_python_testing/__about__.py
+++ b/src/aws_durable_execution_sdk_python_testing/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2025-present Amazon.com, Inc. or its affiliates.
 #
 # SPDX-License-Identifier: Apache-2.0
-__version__ = "1.1.0"
+__version__ = "1.1.1"


### PR DESCRIPTION
Release bump for v1.1.1

Contains:

ea22e3b (HEAD -> 1.1.1, origin/1.1.1) v1.1.0 -> v1.1.1
39f7df3 (origin/main, origin/HEAD, main) refactor: use to/from_json_dict for operation serdes
6d48cac Bump version to 1.1.0 (#186)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
