### PR TITLE
chore: update aws_durable_execution_sdk_python dependency to require at least version 1.1.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 dependencies = [
   "boto3>=1.42.1",
   "requests>=2.25.0",
-  "aws_durable_execution_sdk_python>=1.0.0",
+  "aws_durable_execution_sdk_python>=1.1.2",
 ]
 
 [project.urls]

--- a/src/aws_durable_execution_sdk_python_testing/__about__.py
+++ b/src/aws_durable_execution_sdk_python_testing/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2025-present Amazon.com, Inc. or its affiliates.
 #
 # SPDX-License-Identifier: Apache-2.0
-__version__ = "1.1.1"
+__version__ = "1.1.2"


### PR DESCRIPTION
*Issue #, if available:* 

*Description of changes:*

Updating required aws_durable_execution_sdk_python version so that aws-durable-execution-emulator builds the current newest versions of SDK and testing SDK.


https://github.com/aws/aws-durable-execution-emulator/actions/runs/21500086011/job/61944276267#step:10:616

## Dependencies
If this PR requires testing against a specific branch of the Python Language SDK (e.g., for unreleased changes), uncomment and specify the branch below. Otherwise, leave commented to use the main branch.

<!-- PYTHON_LANGUAGE_SDK_BRANCH: main -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
