### PR TITLE
fix: extend Lambda read_timeout, disable retries

### DIFF
--- a/src/aws_durable_execution_sdk_python_testing/invoker.py
+++ b/src/aws_durable_execution_sdk_python_testing/invoker.py
@@ -7,6 +7,8 @@ from typing import TYPE_CHECKING, Any, Protocol
 from uuid import uuid4
 
 import boto3  # type: ignore
+from botocore.config import Config  # type: ignore
+
 from aws_durable_execution_sdk_python.execution import (
     DurableExecutionInvocationInput,
     DurableExecutionInvocationInputWithClient,
@@ -27,6 +29,26 @@ if TYPE_CHECKING:
 
     from aws_durable_execution_sdk_python_testing.client import InMemoryServiceClient
     from aws_durable_execution_sdk_python_testing.execution import Execution
+
+
+# Max Lambda function timeout is 15 minutes (900s); we give headroom for
+# network round-trip and RIE startup.
+_LAMBDA_READ_TIMEOUT_SECONDS = 960
+_LAMBDA_CLIENT_CONFIG = Config(
+    read_timeout=_LAMBDA_READ_TIMEOUT_SECONDS,
+    retries={"max_attempts": 0},
+)
+
+
+def create_lambda_client(endpoint_url: str | None, region_name: str) -> Any:
+    """Create a boto3 Lambda client configured for durable function invocations."""
+
+    return boto3.client(
+        "lambda",
+        endpoint_url=endpoint_url,
+        region_name=region_name,
+        config=_LAMBDA_CLIENT_CONFIG,
+    )
 
 
 @dataclass(frozen=True)
@@ -136,9 +158,7 @@ class LambdaInvoker(Invoker):
     @staticmethod
     def create(endpoint_url: str, region_name: str) -> LambdaInvoker:
         """Create with the boto lambda client."""
-        invoker = LambdaInvoker(
-            boto3.client("lambda", endpoint_url=endpoint_url, region_name=region_name)
-        )
+        invoker = LambdaInvoker(create_lambda_client(endpoint_url, region_name))
         invoker._current_endpoint = endpoint_url
         invoker._endpoint_clients[endpoint_url] = invoker.lambda_client
         return invoker
@@ -148,8 +168,8 @@ class LambdaInvoker(Invoker):
         # Cache client by endpoint to reuse across executions
         with self._lock:
             if endpoint_url not in self._endpoint_clients:
-                self._endpoint_clients[endpoint_url] = boto3.client(
-                    "lambda", endpoint_url=endpoint_url, region_name=region_name
+                self._endpoint_clients[endpoint_url] = create_lambda_client(
+                    endpoint_url, region_name
                 )
             self.lambda_client = self._endpoint_clients[endpoint_url]
         self._current_endpoint = endpoint_url
@@ -164,10 +184,8 @@ class LambdaInvoker(Invoker):
         # Use provided endpoint or fall back to cached endpoint for this execution
         if lambda_endpoint:
             if lambda_endpoint not in self._endpoint_clients:
-                self._endpoint_clients[lambda_endpoint] = boto3.client(
-                    "lambda",
-                    endpoint_url=lambda_endpoint,
-                    region_name=region_name or "us-east-1",
+                self._endpoint_clients[lambda_endpoint] = create_lambda_client(
+                    lambda_endpoint, region_name or "us-east-1"
                 )
             return self._endpoint_clients[lambda_endpoint]
 

--- a/src/aws_durable_execution_sdk_python_testing/runner.py
+++ b/src/aws_durable_execution_sdk_python_testing/runner.py
@@ -46,6 +46,7 @@ from aws_durable_execution_sdk_python_testing.executor import Executor
 from aws_durable_execution_sdk_python_testing.invoker import (
     InProcessInvoker,
     LambdaInvoker,
+    create_lambda_client,
 )
 from aws_durable_execution_sdk_python_testing.model import (
     GetDurableExecutionHistoryResponse,
@@ -858,9 +859,7 @@ class WebRunner:
             Exception: If client creation fails - exceptions propagate naturally
                       for CLI to handle as general Exception
         """
-        # Create client with Lambda endpoint configuration
-        return boto3.client(
-            "lambda",
+        return create_lambda_client(
             endpoint_url=self._config.lambda_endpoint,
             region_name=self._config.local_runner_region,
         )

--- a/tests/invoker_test.py
+++ b/tests/invoker_test.py
@@ -25,6 +25,8 @@ from aws_durable_execution_sdk_python_testing.execution import Execution
 from aws_durable_execution_sdk_python_testing.invoker import (
     InProcessInvoker,
     LambdaInvoker,
+    _LAMBDA_CLIENT_CONFIG,
+    create_lambda_client,
     create_test_lambda_context,
 )
 from aws_durable_execution_sdk_python_testing.model import (
@@ -133,6 +135,7 @@ def test_lambda_invoker_create():
             "lambda",
             endpoint_url="http://localhost:3001",
             region_name="us-west-2",
+            config=_LAMBDA_CLIENT_CONFIG,
         )
 
 

--- a/tests/runner_web_test.py
+++ b/tests/runner_web_test.py
@@ -12,6 +12,7 @@ from aws_durable_execution_sdk_python_testing.cli import CliApp
 from aws_durable_execution_sdk_python_testing.exceptions import (
     DurableFunctionsLocalRunnerError,
 )
+from aws_durable_execution_sdk_python_testing.invoker import _LAMBDA_CLIENT_CONFIG
 from aws_durable_execution_sdk_python_testing.runner import (
     WebRunner,
     WebRunnerConfig,
@@ -420,6 +421,7 @@ def test_should_handle_boto3_client_creation_with_custom_config():
             "lambda",
             endpoint_url="http://custom-endpoint:8080",
             region_name="eu-west-1",
+            config=_LAMBDA_CLIENT_CONFIG,
         )
 
         # Verify public behavior works
@@ -445,6 +447,7 @@ def test_should_handle_boto3_client_creation_with_defaults():
             "lambda",
             endpoint_url="http://127.0.0.1:3001",  # Default lambda_endpoint value
             region_name="us-west-2",  # Default value
+            config=_LAMBDA_CLIENT_CONFIG,
         )
 
         # Verify public behavior works
@@ -768,6 +771,7 @@ def test_should_pass_correct_boto3_client_to_lambda_invoker():
             "lambda",
             endpoint_url="http://test-endpoint:7777",
             region_name="ap-southeast-2",
+            config=_LAMBDA_CLIENT_CONFIG,
         )
 
         # Verify LambdaInvoker was created with the client


### PR DESCRIPTION
*Issue #, if available:*
#203 

*Description of changes:*

Fixes a crash of SAM local RIE during long-running durable Lambda steps.

botocore's default `read_timeout` of 60s was being used for local-runner Lambda
invocations made by this testing library, so any durable step that ran longer
than 60s would cause a client-side `ReadTimeoutError`. The default
`max_attempts=3` retry policy then re-invoked the still-running Lambda,
compounding the problem.

This change routes Lambda-invocation client construction inside the library
through a single helper that applies a consistent `botocore.config.Config`:

- `read_timeout=960` seconds (Lambda's 900s max runtime + headroom for network
  round-trip and SAM local RIE startup).
- `retries={"max_attempts": 0}` — client-side retries disabled.

Manually tested against the reproduction in the original issue and confirmed that steps running longer than 60s don't cause a crash.

## Dependencies
If this PR requires testing against a specific branch of the Python Language SDK (e.g., for unreleased changes), uncomment and specify the branch below. Otherwise, leave commented to use the main branch.

<!-- PYTHON_LANGUAGE_SDK_BRANCH: main -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
