### PR TITLE
chore: v1.1.2 -> v1.2.0

### DIFF
--- a/src/aws_durable_execution_sdk_python_testing/__about__.py
+++ b/src/aws_durable_execution_sdk_python_testing/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2025-present Amazon.com, Inc. or its affiliates.
 #
 # SPDX-License-Identifier: Apache-2.0
-__version__ = "1.1.2"
+__version__ = "1.2.0"


### PR DESCRIPTION
Bumps testing SDK from v1.1.2 to v1.2.0 in preparation for a new release.

Notable change since v1.1.2:

- c71b5bf — [fix]: input payload too big to fit in initial execution state (#216)

This fix changes `Execution.new()` to construct ARNs as `<uuid>/<invocation_id>` instead of a bare UUID, which is required for compatibility with `aws-durable-execution-sdk-python` v1.5.0 (whose `ExecutionState.get_input_payload()` looks up the EXECUTION operation by `arn.split("/")[-1]`). Without this release, `DurableFunctionTestRunner.run_async(input=...)` causes the handler to receive `{}` instead of the supplied event when paired with main SDK v1.5.0.

## Verification

- `hatch version minor` ran cleanly; `__about__.py` updated 1.1.2 → 1.2.0.
- No code changes in this PR — version bump only.

