### PR TITLE
chore: v1.2.0 -> v1.2.1

### DIFF
--- a/src/aws_durable_execution_sdk_python_testing/__about__.py
+++ b/src/aws_durable_execution_sdk_python_testing/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2025-present Amazon.com, Inc. or its affiliates.
 #
 # SPDX-License-Identifier: Apache-2.0
-__version__ = "1.2.0"
+__version__ = "1.2.1"


### PR DESCRIPTION
Bumps testing SDK from v1.2.0 to v1.2.1 in preparation for a new release.

Notable change since v1.2.0:

- fb8e34c — fix: url-decode path segments in route layer (#223)

This fixes a regression introduced in v1.2.0: `dex-local-runner` (`WebRunner`) returned `404` for every Get/State/History/Checkpoint/Stop call against an execution whose ARN contained a literal `/`, and silently returned an empty list for `ListDurableExecutionsByFunction` when the function name contained `:` or `$`. The cause was that the WebServer's route layer wasn't URL-decoding captured path segments before using them as store-lookup keys, while boto's rest-json serializer percent-encodes those characters in non-greedy URI labels. See #222 for the full bug report.

## Verification

- `hatch version patch` ran cleanly; `__about__.py` updated 1.2.0 → 1.2.1.
- No code changes in this PR — version bump only.
